### PR TITLE
Fix OpenSCAD example 4.

### DIFF
--- a/Graphics/Implicit/ExtOpenScad/Util.hs
+++ b/Graphics/Implicit/ExtOpenScad/Util.hs
@@ -94,7 +94,7 @@ addObj2 obj = return $  \ ioWrappedState -> do
 addObj3 :: (Monad m) => Obj3Type -> m ComputationStateModifier
 addObj3 obj = return $  \ ioWrappedState -> do
 		(varlookup, obj2s, obj3s) <- ioWrappedState
-		return (varlookup, obj2s, obj:obj3s)
+		return (varlookup, obj2s, obj3s ++ [obj])
 
 changeObjs :: (Monad m) => ([Obj2Type] -> [Obj2Type]) -> ([Obj3Type] -> [Obj3Type]) -> m ComputationStateModifier
 changeObjs mod2s mod3s = return $  \ ioWrappedState -> do


### PR DESCRIPTION
Fix for issue with primitive statement ordering within a suite, as demonstrated by OpenSCAD example 4.

Found it at last. But fixing the bug was just a motivator for relearning some Haskell and in that sense it's worked great.
