### PR TITLE
Add missing dependency on JuicyPixels package to cabal

### DIFF
--- a/implicit.cabal
+++ b/implicit.cabal
@@ -29,7 +29,8 @@ Library
         mtl,
         bytestring,
         blaze-builder,
-        storable-endian
+        storable-endian,
+        JuicyPixels
         
     ghc-options:
         -O2 -optc-O3


### PR DESCRIPTION
The build with cabal broke when the ray tracer was added since it depends on Codec.Picture.savePngImage. This seems to be from the JuicyPixels package, so I added this dependency to implicit.cabal.
