### PR TITLE
Comment most of SymbolicObj3 back in.

### DIFF
--- a/Graphics/Implicit/Export/SymbolicObj3.hs
+++ b/Graphics/Implicit/Export/SymbolicObj3.hs
@@ -38,7 +38,6 @@ instance DiscreteAproxable SymbolicObj3 NormedTriangleMesh where
 
 symbolicGetMesh :: ℝ -> SymbolicObj3 -> [(ℝ3, ℝ3, ℝ3)]
 
-{--
 -- A translated objects mesh is its mesh translated.
 symbolicGetMesh res (Translate3 v obj) = 
 	map (\(a,b,c) -> (a S.+ v, b S.+ v, c S.+ v) ) (symbolicGetMesh res obj)
@@ -208,7 +207,6 @@ symbolicGetMesh res  (ExtrudeRM r twist scale translate obj2 h) =
 
 	in
 		map transformTriangle (side_tris ++ bottom_tris ++ top_tris)
--}
 
 symbolicGetMesh res inputObj@(UnionR3 r objs) = 
 	let


### PR DESCRIPTION
3D rendering seems to have been buggy since April, between versions 0.0.1 and 0.0.2. Objects with sharp edges, such as cubes and cylinders, get rendered with those edges "crinkled". You can see this by rendering the sample code of the first 3D object in README.md with the latest version of ImplicitCAD. It looks much uglier than the picture in the readme.

I bisected this to have happened in commit 14af9390, where most of the SymbolicObj3.hs was commented out. This seems to have disabled symbolic object rendering, so everything is done with marching cubes.

I don't know if this is the right fix, but at least this makes  the examples from the readme pretty again. I haven't tested whether all the code that gets revived here actually works, but at least it compiles without problems.
