### PR TITLE
Build with unordered-containers instead of hashmap

### DIFF
--- a/implicit.cabal
+++ b/implicit.cabal
@@ -19,7 +19,7 @@ Library
     Build-Depends:
         base >= 3 && < 5,
         parsec,
-        hashmap,
+        unordered-containers,
         parallel,
         containers,
         plugins,


### PR DESCRIPTION
It seems that things might be a bit faster now, although it's very close to within noise. Either way, it's always better to use the more accepted (and certainly better maintained) library where possible.
