### PR TITLE
Add viewBox entry to svg files (colah/ImplicitCAD#83)

### DIFF
--- a/Graphics/Implicit/Export/PolylineFormats.hs
+++ b/Graphics/Implicit/Export/PolylineFormats.hs
@@ -15,7 +15,7 @@ import Text.Blaze.Svg11 ((!),docTypeSvg,g,polyline,toValue)
 import Text.Blaze.Internal (stringValue)
 import qualified Text.Blaze.Svg11.Attributes as A
 
-import Data.List (foldl')
+import Data.List (foldl',intersperse)
 import qualified Data.List as List
 
 svg :: [Polyline] -> Text
@@ -27,6 +27,7 @@ svg plines = renderSvg . svg11 . svg' $ plines
       svg11 content = docTypeSvg ! A.version "1.1" 
                                  ! A.width  (stringValue $ show (xmax-xmin) ++ "mm")
                                  ! A.height (stringValue $ show (ymax-ymin) ++ "mm")
+                                 ! A.viewbox (stringValue $ concat . intersperse " " . map show $ [xmin, xmax, ymin, ymax])
                                  $ content
       -- The reason this isn't totally straightforwards is that svg has different coordinate system
       -- and we need to compute the requisite translation.


### PR DESCRIPTION
 Add viewBox entry to exported svg files to allow inkscape to size them correctly (colah/ImplicitCAD#83)
