### PR TITLE
Scale bbox fix

### DIFF
--- a/Graphics/Implicit/ObjectUtil/GetBox2.hs
+++ b/Graphics/Implicit/ObjectUtil/GetBox2.hs
@@ -77,20 +77,25 @@ getBox2 (Translate2 v symbObj) =
         then ((0,0),(0,0))
         else (a^+^v, b^+^v)
 getBox2 (Scale2 s symbObj) =
-    let
+  let
         (a,b) = getBox2 symbObj
-    in
-        (s ⋯* a, s ⋯* b)
+        ((x_a,y_a),(x_b,y_b)) = (s ⋯* a, s ⋯* b)
+        a' = (min x_a x_b, min y_a y_b)
+        b' = (max x_a x_b, max y_a y_b)
+  in
+        (a',b')
+
 getBox2 (Rotate2 θ symbObj) =
-    let
+  let
         ((x1,y1), (x2,y2)) = getBox2 symbObj
         rotate (x,y) = (cos(θ)*x - sin(θ)*y, sin(θ)*x + cos(θ)*y)
-    in
+  in
         pointsBox [ rotate (x1, y1)
                   , rotate (x1, y2)
                   , rotate (x2, y1)
                   , rotate (x2, y2)
                   ]
+
 -- Boundary mods
 getBox2 (Shell2 w symbObj) =
     outsetBox (w/2) $ getBox2 symbObj

--- a/Graphics/Implicit/ObjectUtil/GetBox3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetBox3.hs
@@ -75,10 +75,14 @@ getBox3 (Translate3 v symbObj) =
     in
         (a^+^v, b^+^v)
 getBox3 (Scale3 s symbObj) =
-    let
+  let
         (a,b) = getBox3 symbObj
-    in
-        (s ⋯* a, s ⋯* b)
+        ((x_a,y_a,z_a),(x_b,y_b,z_b)) = (s ⋯* a, s ⋯* b)
+        a' = (min x_a x_b, min y_a y_b, min z_a z_b)
+        b' = (max x_a x_b, max y_a y_b, min z_a z_b)
+  in
+        (a',b')
+
 getBox3 (Rotate3 _ symbObj) = ( (-d, -d, -d), (d, d, d) )
     where
         ((x1,y1, z1), (x2,y2, z2)) = getBox3 symbObj


### PR DESCRIPTION
Currently, Scaling an object by a vector that contains a negative component will create a bounding box that is incorrect. In particular the box's a compontent is no longer the 'lower left corner' and the b component is no longer the 'upper right corner' (these do not correctly describe the 3d case). While this pull request may not be the best solution to the problem at hand, it is certainly a small diff.

This does allow someone to 'mirror' with the scale command and negavite components, but I am still not sure that is a good idea, as all negative components or later scaling could invert the object.
