### PR TITLE
Set version boundaries on optparse-applicative

### DIFF
--- a/implicit.cabal
+++ b/implicit.cabal
@@ -20,7 +20,7 @@ Library
         base >= 3 && < 5,
         filepath,
         directory,
-        optparse-applicative,
+        optparse-applicative >= 0.9.0.0 && < 0.10.0,
         parsec,
         unordered-containers,
         parallel,


### PR DESCRIPTION
This patch was all I needed to get implicit working for me.  Please include this so I can drop my local patch soon.  Thanks!
