### PR TITLE
Lowered upper bound on optparse-applicative so we can build

### DIFF
--- a/implicit.cabal
+++ b/implicit.cabal
@@ -20,7 +20,7 @@ Library
         base >= 3 && < 5,
         filepath,
         directory,
-        optparse-applicative >= 0.9.0.0 && < 0.10.0,
+        optparse-applicative >= 0.9.0.0 && < 0.9.1.1,
         parsec,
         unordered-containers,
         parallel,


### PR DESCRIPTION
Changes to optparse-applicative in version 0.9.1.1 break implicitCad.