### PR TITLE
implicit-0.0.3 fails to build on ghc-7.10.1: No instance for (Applicative ArgParser)

### DIFF
--- a/Graphics/Implicit/Export.hs
+++ b/Graphics/Implicit/Export.hs
@@ -1,5 +1,6 @@
 -- Implicit CAD. Copyright (C) 2011, Christopher Olah (chris@colah.ca)
 -- Released under the GNU GPL, see LICENSE
+{-# LANGUAGE FlexibleContexts #-}
 
 module Graphics.Implicit.Export where
 

--- a/Graphics/Implicit/Export/RayTrace.hs
+++ b/Graphics/Implicit/Export/RayTrace.hs
@@ -1,5 +1,5 @@
 
-{-# LANGUAGE TypeSynonymInstances, MultiParamTypeClasses #-}
+{-# LANGUAGE TypeSynonymInstances, MultiParamTypeClasses, FlexibleContexts #-}
 
 module Graphics.Implicit.Export.RayTrace where
 

--- a/Graphics/Implicit/ExtOpenScad/Util/ArgParser.hs
+++ b/Graphics/Implicit/ExtOpenScad/Util/ArgParser.hs
@@ -8,7 +8,19 @@ import Graphics.Implicit.ExtOpenScad.Util.OVal
 import qualified Control.Exception as Ex
 import qualified Data.Map   as Map
 import qualified Data.Maybe as Maybe
+import Control.Applicative
 import Control.Monad
+
+instance Alternative ArgParser where
+	(<|>) = mplus
+	empty = mzero
+
+instance Functor ArgParser where
+	fmap  = liftM
+
+instance Applicative ArgParser where
+	pure = return
+	(<*>) = ap
 
 instance Monad ArgParser where
 

--- a/implicit.cabal
+++ b/implicit.cabal
@@ -43,6 +43,7 @@ Library
         -rtsopts
         -funfolding-use-threshold=16 
         -fspec-constr-count=10
+        -fno-warn-tabs
 
     Extensions:
         FlexibleContexts,
@@ -120,6 +121,7 @@ Executable extopenscad
         -rtsopts
         -funfolding-use-threshold=16 
         -fspec-constr-count=10
+        -fno-warn-tabs
 
 source-repository head
     type:            git

--- a/implicit.cabal
+++ b/implicit.cabal
@@ -20,7 +20,7 @@ Library
         base >= 3 && < 5,
         filepath,
         directory,
-        optparse-applicative >= 0.9.0.0 && < 0.10.0,
+        optparse-applicative >= 0.10.0,
         parsec,
         unordered-containers,
         parallel,


### PR DESCRIPTION
Graphics/Implicit/ExtOpenScad/Util/ArgParser.hs:13:10:
    No instance for (Applicative ArgParser)
      arising from the superclasses of an instance declaration
    In the instance declaration for ‘Monad ArgParser’

Graphics/Implicit/ExtOpenScad/Util/ArgParser.hs:31:10:
    No instance for (GHC.Base.Alternative ArgParser)
      arising from the superclasses of an instance declaration
    In the instance declaration for ‘MonadPlus ArgParser’