### PR TITLE
Comply with new updates to 7.8

### DIFF
--- a/Graphics/Implicit/Export/PolylineFormats.hs
+++ b/Graphics/Implicit/Export/PolylineFormats.hs
@@ -27,15 +27,13 @@ svg plines = renderSvg . svg11 . svg' $ plines
       svg11 content = docTypeSvg ! A.version "1.1" 
                                  ! A.width  (stringValue $ show (xmax-xmin) ++ "mm")
                                  ! A.height (stringValue $ show (ymax-ymin) ++ "mm")
-                                 ! A.viewbox (stringValue $ concat . intersperse " " . map show $ [xmin, xmax, ymin, ymax])
+                                 ! A.viewbox (stringValue $ concat . intersperse " " . map show $ [xmin, ymin, xmax, ymax])
                                  $ content
       -- The reason this isn't totally straightforwards is that svg has different coordinate system
       -- and we need to compute the requisite translation.
       svg' [] = mempty 
       -- When we have a known point, we can compute said transformation:
       svg' polylines = thinBlueGroup $ mapM_ poly polylines
-      -- Otherwise, if we don't have a point to start out with, skip this polyline:
-      svg' ([]:rest) = svg' rest
 
       poly line = polyline ! A.points pointList 
           where pointList = toValue $ toLazyText $ mconcat [bf (x-xmin) <> "," <> bf (ymax - y) <> " " | (x,y) <- line]

--- a/Graphics/Implicit/Export/PolylineFormats.hs
+++ b/Graphics/Implicit/Export/PolylineFormats.hs
@@ -15,7 +15,7 @@ import Text.Blaze.Svg11 ((!),docTypeSvg,g,polyline,toValue)
 import Text.Blaze.Internal (stringValue)
 import qualified Text.Blaze.Svg11.Attributes as A
 
-import Data.List (foldl',intersperse)
+import Data.List (foldl')
 import qualified Data.List as List
 
 svg :: [Polyline] -> Text
@@ -27,13 +27,15 @@ svg plines = renderSvg . svg11 . svg' $ plines
       svg11 content = docTypeSvg ! A.version "1.1" 
                                  ! A.width  (stringValue $ show (xmax-xmin) ++ "mm")
                                  ! A.height (stringValue $ show (ymax-ymin) ++ "mm")
-                                 ! A.viewbox (stringValue $ concat . intersperse " " . map show $ [xmin, ymin, xmax, ymax])
+                                 ! A.viewbox (stringValue $ concat . intersperse " " . map show $ [xmin, xmax, ymin, ymax])
                                  $ content
       -- The reason this isn't totally straightforwards is that svg has different coordinate system
       -- and we need to compute the requisite translation.
       svg' [] = mempty 
       -- When we have a known point, we can compute said transformation:
       svg' polylines = thinBlueGroup $ mapM_ poly polylines
+      -- Otherwise, if we don't have a point to start out with, skip this polyline:
+      svg' ([]:rest) = svg' rest
 
       poly line = polyline ! A.points pointList 
           where pointList = toValue $ toLazyText $ mconcat [bf (x-xmin) <> "," <> bf (ymax - y) <> " " | (x,y) <- line]

--- a/Graphics/Implicit/Export/PolylineFormats.hs
+++ b/Graphics/Implicit/Export/PolylineFormats.hs
@@ -15,7 +15,7 @@ import Text.Blaze.Svg11 ((!),docTypeSvg,g,polyline,toValue)
 import Text.Blaze.Internal (stringValue)
 import qualified Text.Blaze.Svg11.Attributes as A
 
-import Data.List (foldl')
+import Data.List (foldl',intersperse)
 import qualified Data.List as List
 
 svg :: [Polyline] -> Text

--- a/Graphics/Implicit/Export/TextBuilderUtils.hs
+++ b/Graphics/Implicit/Export/TextBuilderUtils.hs
@@ -28,7 +28,7 @@ import Data.Text.Lazy
 import qualified Data.Monoid as Monoid
 
 import Data.Text.Lazy
-import Data.Text.Lazy.Internal (defaultChunkSize)
+import Data.Text.Internal.Lazy (defaultChunkSize)
 import Data.Text.Lazy.Builder hiding (toLazyText)
 import Data.Text.Lazy.Builder.RealFloat
 import Data.Text.Lazy.Builder.Int

--- a/Graphics/Implicit/ExtOpenScad/Util/ArgParser.hs
+++ b/Graphics/Implicit/ExtOpenScad/Util/ArgParser.hs
@@ -9,9 +9,9 @@ import qualified Control.Exception as Ex
 import qualified Data.Map   as Map
 import qualified Data.Maybe as Maybe
 import Control.Monad
+import Control.Applicative
 
 instance Monad ArgParser where
-
 	-- return is easy: if we want an ArgParser that just gives us a, that is 
 	-- ArgParserTerminator a
 	return a = APTerminator a
@@ -28,12 +28,23 @@ instance Monad ArgParser where
 	(APTerminator a) >>= g = g a
 	(APBranch bs) >>= g = APBranch $ map (>>= g) bs
 
+instance Functor ArgParser where
+    fmap = liftM
+
+instance Applicative ArgParser where
+    pure = return
+    (<*>) = ap
+
 instance MonadPlus ArgParser where
 	mzero = APFailIf True "" undefined
 	mplus (APBranch as) (APBranch bs) = APBranch ( as  ++  bs )
 	mplus (APBranch as) b             = APBranch ( as  ++ [b] )
 	mplus a             (APBranch bs) = APBranch ( [a] ++  bs )
 	mplus a             b             = APBranch [ a   ,   b  ]
+
+instance Alternative ArgParser where
+    (<|>) = mplus
+    empty = mzero
 
 -- * ArgParser building functions
 


### PR DESCRIPTION
I've created two change lists. One creates instances for Functor, Applicative, Monad, and Alternate for ArgParser to comply with the Applicative Functor Proposal in GHC 7.10 (currently warning in 7.8) and the other replaces a depreciated module import with its suggested replacement. 