### PR TITLE
Fixing a bug where in the SVG exporter got the viewBox arguments in t…

### DIFF
--- a/Graphics/Implicit/Export/PolylineFormats.hs
+++ b/Graphics/Implicit/Export/PolylineFormats.hs
@@ -27,15 +27,13 @@ svg plines = renderSvg . svg11 . svg' $ plines
       svg11 content = docTypeSvg ! A.version "1.1" 
                                  ! A.width  (stringValue $ show (xmax-xmin) ++ "mm")
                                  ! A.height (stringValue $ show (ymax-ymin) ++ "mm")
-                                 ! A.viewbox (stringValue $ concat . intersperse " " . map show $ [xmin, xmax, ymin, ymax])
+                                 ! A.viewbox (stringValue $ concat . intersperse " " . map show $ [xmin, ymin, xmax, ymax])
                                  $ content
       -- The reason this isn't totally straightforwards is that svg has different coordinate system
       -- and we need to compute the requisite translation.
       svg' [] = mempty 
       -- When we have a known point, we can compute said transformation:
       svg' polylines = thinBlueGroup $ mapM_ poly polylines
-      -- Otherwise, if we don't have a point to start out with, skip this polyline:
-      svg' ([]:rest) = svg' rest
 
       poly line = polyline ! A.points pointList 
           where pointList = toValue $ toLazyText $ mconcat [bf (x-xmin) <> "," <> bf (ymax - y) <> " " | (x,y) <- line]


### PR DESCRIPTION
1) I've changed the order of the arguments to be x,y,width,height according to the documentation on w3c.
2) I've used 0,0 for x,y instead of xmin,ymin as they are getting normalized in the poly function and this causes the viewing window to be way off.
3) I've gotten rid of a dead-code line in svg' which you can see in the pattern match is unreachable. 
4) I've used unwords in place of (concat . intersperse " ") as it is a synonym for it which does not require any imports.