### PR TITLE
Fixing bugs in SVG header

### DIFF
--- a/Graphics/Implicit/Export/PolylineFormats.hs
+++ b/Graphics/Implicit/Export/PolylineFormats.hs
@@ -15,7 +15,7 @@ import Text.Blaze.Svg11 ((!),docTypeSvg,g,polyline,toValue)
 import Text.Blaze.Internal (stringValue)
 import qualified Text.Blaze.Svg11.Attributes as A
 
-import Data.List (foldl',intersperse)
+import Data.List (foldl')
 import qualified Data.List as List
 
 svg :: [Polyline] -> Text
@@ -27,15 +27,13 @@ svg plines = renderSvg . svg11 . svg' $ plines
       svg11 content = docTypeSvg ! A.version "1.1" 
                                  ! A.width  (stringValue $ show (xmax-xmin) ++ "mm")
                                  ! A.height (stringValue $ show (ymax-ymin) ++ "mm")
-                                 ! A.viewbox (stringValue $ concat . intersperse " " . map show $ [xmin, xmax, ymin, ymax])
+                                 ! A.viewbox (stringValue $ unwords . map show $ [0,0,xmax-xmin,ymax-ymin])
                                  $ content
       -- The reason this isn't totally straightforwards is that svg has different coordinate system
       -- and we need to compute the requisite translation.
       svg' [] = mempty 
       -- When we have a known point, we can compute said transformation:
       svg' polylines = thinBlueGroup $ mapM_ poly polylines
-      -- Otherwise, if we don't have a point to start out with, skip this polyline:
-      svg' ([]:rest) = svg' rest
 
       poly line = polyline ! A.points pointList 
           where pointList = toValue $ toLazyText $ mconcat [bf (x-xmin) <> "," <> bf (ymax - y) <> " " | (x,y) <- line]


### PR DESCRIPTION
1) Swapping the order of the arguments in viewBox. They previously did not comply with the standard.
2) Using 0,0 as origin since we're normalizing to the origin in the poly function anyway
3) Deleting unreachable code from svg'
4) Using unwords in place of (contact . intersperse " ")