### PR TITLE
Reorder getDist2 pattern match to allow it to reach currently dead code.

### DIFF
--- a/Graphics/Implicit/ObjectUtil/GetBox2.hs
+++ b/Graphics/Implicit/ObjectUtil/GetBox2.hs
@@ -116,11 +116,11 @@ getDist2 p (Translate2 v obj) = getDist2 (p ^+^ v) obj
 
 getDist2 p (Circle r) = magnitude p + r
 
+getDist2 p (PolygonR r points) = 
+	r + maximum [magnitude (p ^-^ p') | p' <- points]
+
 getDist2 (x,y) symbObj =
 	let
 		((x1,y1), (x2,y2)) = getBox2 symbObj
 	in
 		sqrt ((max (abs (x1 - x)) (abs (x2 - x)))^2 + (max (abs (y1 - y)) (abs (y2 - y)))^2)
-
-getDist2 p (PolygonR r points) = 
-	r + maximum [magnitude (p ^-^ p') | p' <- points]


### PR DESCRIPTION
We currently have an issue where the Polygon pattern match in getDist2 is unreachable due to the catch-all pattern match immediately above it. This causes us to fall back on getting the distance on a getBox2 rectangle instead of the more precise, and formerly unreachable, code in the body of the code I'm moving up.