### PR TITLE
Only use instance-specific overlapping and overlapped declarations. 

### DIFF
--- a/Graphics/Implicit/Definitions.hs
+++ b/Graphics/Implicit/Definitions.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, TypeSynonymInstances, OverlappingInstances #-}
+{-# LANGUAGE FlexibleInstances, TypeSynonymInstances #-}
 
 -- Implicit CAD. Copyright (C) 2011, Christopher Olah (chris@colah.ca)
 -- Released under the GNU GPL, see LICENSE
@@ -10,8 +10,6 @@ module Graphics.Implicit.Definitions where
 import Data.IORef (IORef, newIORef, readIORef)
 import System.IO.Unsafe (unsafePerformIO)
 import Data.VectorSpace       
-import Control.Applicative
-import Data.NumInstances
 
 -- Let's make things a bit nicer. 
 -- Following math notation ℝ, ℝ², ℝ³...
@@ -182,9 +180,9 @@ errorMessage line msg = do
             dropXML inQuote True  ( _ :xs) =   dropXML inQuote True  xs
             dropXML inQuote False ( x :xs) = x:dropXML inQuote False xs
             dropXML _       _        []    = []
-        if useXML 
-            then putStrLn $ "<error>" ++ msg' ++ "</error>"
-            else putStrLn $ dropXML False False $ msg'
+        putStrLn $ if useXML 
+                   then "<error>" ++ msg' ++ "</error>"
+                   else dropXML False False msg'
         return ()
 
 -- HACK: This needs to be fixed correctly someday

--- a/Graphics/Implicit/ExtOpenScad/Util/OVal.hs
+++ b/Graphics/Implicit/ExtOpenScad/Util/OVal.hs
@@ -1,5 +1,4 @@
-
-{-# LANGUAGE ViewPatterns, RankNTypes, ScopedTypeVariables, TypeSynonymInstances, FlexibleInstances, OverlappingInstances  #-}
+{-# LANGUAGE ViewPatterns, RankNTypes, ScopedTypeVariables, TypeSynonymInstances, FlexibleInstances #-}
 
 module Graphics.Implicit.ExtOpenScad.Util.OVal where
 
@@ -32,7 +31,7 @@ instance OTypeMirror Bool where
     fromOObj _ = Nothing
     toOObj b = OBool b
 
-instance OTypeMirror String where
+instance {-# Overlapping #-} OTypeMirror String where
     fromOObj (OString str) = Just str
     fromOObj _ = Nothing
     toOObj str = OString str
@@ -42,7 +41,7 @@ instance forall a. (OTypeMirror a) => OTypeMirror (Maybe a) where
     toOObj (Just a) = toOObj a
     toOObj Nothing  = OUndefined
 
-instance forall a. (OTypeMirror a) => OTypeMirror [a] where
+instance {-# Overlappable #-} forall a. (OTypeMirror a) => OTypeMirror [a] where
     fromOObj (OList list) = Monad.sequence . map fromOObj $ list
     fromOObj _ = Nothing
     toOObj list = OList $ map toOObj list


### PR DESCRIPTION
Fixing warnings and hlint issues in files visited while I'm in there.