### PR TITLE
Compatibility fixes with older GHC versions

### DIFF
--- a/Graphics/Implicit/Export/TextBuilderUtils.hs
+++ b/Graphics/Implicit/Export/TextBuilderUtils.hs
@@ -28,12 +28,28 @@ import Data.Text.Lazy
 import qualified Data.Monoid as Monoid
 
 import Data.Text.Lazy
-import Data.Text.Internal.Lazy (defaultChunkSize)
 import Data.Text.Lazy.Builder hiding (toLazyText)
 import Data.Text.Lazy.Builder.RealFloat
 import Data.Text.Lazy.Builder.Int
 
+import Foreign.Storable (sizeOf)
+import Data.Bits (shiftL)
+
 import Graphics.Implicit.Definitions
+
+-- Helper functions from Data.Text.Internal.Lazy.  These functions are needed
+-- here instead of imported as the API is not meant to be used in this way and
+-- is broken in some version of the Text library.
+-- DO NOT EXPORT from this module
+defaultChunkSize :: Int
+defaultChunkSize = 16384 - chunkOverhead
+{-# INLINE defaultChunkSize #-}
+
+-- DO NOT EXPORT from this module
+-- | The memory management overhead. Currently this is tuned for GHC only.
+chunkOverhead :: Int
+chunkOverhead = sizeOf (undefined :: Int) `shiftL` 1
+{-# INLINE chunkOverhead #-}
 
 -- The chunk size for toLazyText is very small (128 bytes), so we export
 -- a version with a much larger size (~16 K)

--- a/Graphics/Implicit/ExtOpenScad/Util/OVal.hs
+++ b/Graphics/Implicit/ExtOpenScad/Util/OVal.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ViewPatterns, RankNTypes, ScopedTypeVariables, TypeSynonymInstances, FlexibleInstances #-}
+{-# LANGUAGE OverlappingInstances, ViewPatterns, RankNTypes, ScopedTypeVariables, TypeSynonymInstances, FlexibleInstances #-}
 
 module Graphics.Implicit.ExtOpenScad.Util.OVal where
 

--- a/extopenscad.hs
+++ b/extopenscad.hs
@@ -22,10 +22,7 @@ import Control.Applicative
 import Options.Applicative (fullDesc, progDesc, header, auto, info, helper, help, str, argument, switch, value, long, short, option, metavar, execParser, Parser)
 import System.FilePath
 
--- Backwards compatibility with old versions of Data.Monoid:
-infixr 6 <>
-(<>) :: Monoid a => a -> a -> a
-(<>) = mappend
+import Data.Monoid ((<>), mappend, mempty)
 
 data ExtOpenScadOpts = ExtOpenScadOpts
     { outputFile :: Maybe FilePath


### PR DESCRIPTION
These patches make ImplicitCAD build again on GHC 7.6.3 and should provide better compatibility across GHC versions.