### PR TITLE
package doesn't support GHC < 7.4

### DIFF
--- a/implicit.cabal
+++ b/implicit.cabal
@@ -17,7 +17,7 @@ Category:            Graphics
 Library
 
     Build-Depends:
-        base >= 3 && < 5,
+        base >= 4.5 && < 5,
         filepath,
         directory,
         optparse-applicative >= 0.10.0,


### PR DESCRIPTION
I revised existing versions: https://hackage.haskell.org/package/implicit-0.0.5/revisions/ . The new build matrix is here: http://matrix.hackage.haskell.org/package/implicit

A new release isn't needed but for the next release please either merge this to mark older GHCs as not supported, or add backwards compatibility.

