### PR TITLE
OVal.hs: fix typo which broke the compilation

### DIFF
--- a/Graphics/Implicit/ExtOpenScad/Util/OVal.hs
+++ b/Graphics/Implicit/ExtOpenScad/Util/OVal.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__ < 710
-{-# LANGUAGE OverlappingInstances -#}
+{-# LANGUAGE OverlappingInstances #-}
 #endif
+
 {-# LANGUAGE ViewPatterns, RankNTypes, ScopedTypeVariables, TypeSynonymInstances, FlexibleInstances #-}
 
 module Graphics.Implicit.ExtOpenScad.Util.OVal where


### PR DESCRIPTION
I've tries to compile ImplicitCAD by GHC 7.6, and spotted the following error:

```diff
-{-# LANGUAGE OverlappingInstances -#}
+{-# LANGUAGE OverlappingInstances #-}
```

Maybe it worth having some CI configured to prevent bugs like this from the very appearing? At least [Travis-CI][1]?

[1]: https://travis-ci.org