### PR TITLE
Extend and refactor parser tests

### DIFF
--- a/tests/ParserSpec/Expr.hs
+++ b/tests/ParserSpec/Expr.hs
@@ -11,30 +11,36 @@ import Data.Either
 infixr 1 -->
 (-->) :: String -> Expr -> Expectation
 (-->) source expr =
-  (parseExpr source) `shouldBe` Right expr
+  parse (expr0 <* eof) "<expr>" source `shouldBe` Right expr
 
 infixr 1 -->+
 (-->+) :: String -> (Expr, String) -> Expectation
 (-->+) source (result, leftover) =
-  (parseWithLeftOver expr0 source) `shouldBe` (Right (result, leftover))
+  parseWithLeftOver expr0 source `shouldBe` Right (result, leftover)
 
 ternaryIssue :: Expectation -> Expectation
 ternaryIssue _ = pendingWith "parser doesn't handle ternary operator correctly"
 
+negationIssue :: Expectation -> Expectation
+negationIssue _ = pendingWith "parser doesn't handle negation operator correctly"
+
 logicalSpec :: Spec
 logicalSpec = do
-  it "handles not" $ "!foo" --> (app' "!" [Var "foo"])
+  describe "not" $ do
+    specify "single" $ "!foo" --> (app "!" [Var "foo"])
+    specify "multiple" $
+      negationIssue $ "!!!foo" --> app "!" [app "!" [app "!" [Var "foo"]]]
   it "handles and/or" $ do
-    "foo && bar" --> app' "&&" [Var "foo", Var "bar"]
-    "foo || bar" --> app' "||" [Var "foo", Var "bar"]
+    "foo && bar" --> app "&&" [Var "foo", Var "bar"]
+    "foo || bar" --> app "||" [Var "foo", Var "bar"]
   describe "ternary operator" $ do
     specify "with primitive expressions" $
-      "x ? 2 : 3" --> app' "?" [Var "x", num 2, num 3]
+      "x ? 2 : 3" --> app "?" [Var "x", num 2, num 3]
     specify "with comparison in head position" $
       ternaryIssue $ "1 > 0 ? 5 : -5" --> app' "?" [app' ">" [num 1, num 0], num 5, num (-5)]
     specify "with comparison in head position, and addition in tail" $
       ternaryIssue $ "1 > 0 ? 5 : 1 + 2" -->
-      app' "?" [app' ">" [num 1, num 0], num 5, app "+" [num 1, num 2]]
+      app "?" [app ">" [num 1, num 0], num 5, plus [num 1, num 2]]
 
 literalSpec :: Spec
 literalSpec = do
@@ -63,7 +69,7 @@ exprSpec = do
       "( 1, 2, 3 )" -->  ListE [num 1, num 2, num 3]
     it "handles generators" $
       "[ a : 1 : b + 10 ]" -->
-      (app "list_gen" [Var "a", num 1, app "+" [Var "b", num 10]])
+      (app' "list_gen" [Var "a", num 1, plus [Var "b", num 10]])
     it "handles indexing" $
       "foo[23]" --> Var "index" :$ [Var "foo", num 23]
 
@@ -72,30 +78,39 @@ exprSpec = do
       "-42" --> num (-42)
       "+42" -->  num 42
     it "handles +" $ do
-      "1 + 2" --> app "+" [num 1, num 2]
-      "1 + 2 + 3" --> app "+" [num 1, num 2, num 3]
+      "1 + 2" --> plus [num 1, num 2]
+      "1 + 2 + 3" --> plus [num 1, num 2, num 3]
     it "handles -" $ do
-      "1 - 2" --> app' "-" [num 1, num 2]
-      "1 - 2 - 3" --> app' "-" [app' "-" [num 1, num 2], num 3]
+      "1 - 2" --> minus [num 1, num 2]
+      "1 - 2 - 3" --> minus [minus [num 1, num 2], num 3]
     it "handles +/- in combination" $ do
-      "1 + 2 - 3" --> app "+" [num 1, app' "-" [num 2, num 3]]
-      "2 - 3 + 4" --> app "+" [app' "-" [num 2, num 3], num 4]
-      "1 + 2 - 3 + 4" --> app "+" [num 1, app' "-" [num 2, num 3], num 4]
-      "1 + 2 - 3 + 4 - 5 - 6" --> app "+" [num 1,
-                                           app' "-" [num 2, num 3],
-                                           app' "-" [app' "-" [num 4, num 5],
-                                                     num 6]]
+      "1 + 2 - 3" --> plus [num 1, minus [num 2, num 3]]
+      "2 - 3 + 4" --> plus [minus [num 2, num 3], num 4]
+      "1 + 2 - 3 + 4" --> plus [num 1, minus [num 2, num 3], num 4]
+      "1 + 2 - 3 + 4 - 5 - 6" --> plus [num 1, minus [num 2, num 3],
+                                        minus [minus [num 4, num 5], num 6]]
+    it "handles modulo" $
+      "x % y" --> modulo [Var "x", Var "y"]
     it "handles exponentiation" $
-      "x ^ y" -->  app' "^" [Var "x", Var "y"]
+      "x ^ y" -->  power [Var "x", Var "y"]
     it "handles *" $ do
-      "3 * 4" -->  app "*" [num 3, num 4]
-      "3 * 4 * 5" -->  app "*" [num 3, num 4, num 5]
+      "3 * 4" -->  mult [num 3, num 4]
+      "3 * 4 * 5" -->  mult [num 3, num 4, num 5]
     it "handles /" $
-      "4.2 / 2.3" -->  app' "/" [num 4.2, num 2.3]
+      "4.2 / 2.3" -->  divide [num 4.2, num 2.3]
     it "handles precedence" $
-      parseExpr "1 + 2 / 3 * 5" `shouldBe`
-      (Right $ app "+" [num 1, app "*" [app' "/" [num 2, num 3], num 5]])
+      "1 + 2 / 3 * 5" --> plus [num 1, mult [divide [num 2, num 3], num 5]]
   it "handles append" $
-    parseExpr "foo ++ bar ++ baz" `shouldBe`
-    (Right $ app "++" [Var "foo", Var "bar", Var "baz"])
+    "foo ++ bar ++ baz" --> app' "++" [Var "foo", Var "bar", Var "baz"]
   describe "logical operators" logicalSpec
+
+  describe "application" $ do
+    specify "base case" $ "foo(x)" --> Var "foo" :$ [Var "x"]
+    specify "multiple arguments" $
+      "foo(x, 1, 2)" --> Var "foo" :$ [Var "x", num 1, num 2]
+    specify "multiple" $
+      "foo(x, 1, 2)(5)(y)" --> ((Var "foo" :$ [Var "x", num 1, num 2])
+                                :$ [num 5]) :$ [Var "y"]
+    specify "multiple, with indexing" $
+      "foo(x)[0](y)" --> ((app "index" [(Var "foo" :$ [Var "x"]), num 0])
+                          :$ [Var "y"])

--- a/tests/ParserSpec/Statement.hs
+++ b/tests/ParserSpec/Statement.hs
@@ -40,11 +40,11 @@ assignmentSpec = do
     "function foo(x, y) = x * y;" `parsesAs` single fooFunction
   it "nested indexing" $
     "x = [y[0] - z * 2];" `parsesAs`
-    (single $ Name "x" := ListE [app' "-" [app' "index" [Var "y", num 0],
-                                           app "*" [Var "z", num 2]]])
+    (single $ Name "x" := ListE [minus [app "index" [Var "y", num 0],
+                                        mult [Var "z", num 2]]])
   where
     fooFunction = Name "foo" := (LamE [Name "x", Name "y"]
-                                 (app "*" [Var "x", Var "y"]))
+                                 (mult [Var "x", Var "y"]))
 
 emptyFileIssue :: Expectation -> Expectation
 emptyFileIssue _ = pendingWith "parser should probably allow empty files"

--- a/tests/ParserSpec/Util.hs
+++ b/tests/ParserSpec/Util.hs
@@ -3,9 +3,13 @@ module ParserSpec.Util
        , bool
        , app
        , app'
-       , parseWithEof
+       , plus
+       , minus
+       , divide
+       , modulo
+       , power
+       , mult
        , parseWithLeftOver
-       , parseExpr
        ) where
 
 import Graphics.Implicit.Definitions
@@ -21,25 +25,25 @@ num :: ℝ -> Expr
 num x
   -- note that the parser should handle negative number literals
   -- directly, we abstract that deficiency away here
-  | x < 0 = app' "negate" [LitE $ ONum (-x)]
+  | x < 0 = app "negate" [LitE $ ONum (-x)]
   | otherwise = LitE $ ONum x
 
 bool :: Bool -> Expr
 bool = LitE . OBool
 
 -- Operators and functions need two different kinds of applications
-app :: String -> [Expr] -> Expr
-app name args = Var name :$ [ListE args]
+app, app' :: String -> [Expr] -> Expr
+app name args = Var name :$ args
+app' name args = Var name :$ [ListE args]
 
-app' :: Symbol -> [Expr] -> Expr
-app' name args = Var name :$ args
+plus, minus, mult, modulo, power :: [Expr] -> Expr
+plus = app' "+"
+minus = app "-"
+mult = app' "*"
+modulo = app "%"
+power = app "^"
+divide = app "/"
 
 parseWithLeftOver :: Parser a -> String -> Either ParseError (a, String)
 parseWithLeftOver p = parse ((,) <$> p <*> leftOver) ""
   where leftOver = manyTill anyToken eof
-
-parseWithEof :: Parser a -> String -> String -> Either ParseError a
-parseWithEof p = parse (p <* eof)
-
-parseExpr :: String -> Either ParseError Expr
-parseExpr = parseWithEof expr0 "expr"


### PR DESCRIPTION
Besides a few cosmetic touches, and adding a some test cases, the main
points are:
- Abstract away the subtleties of the arithmetic operators'
  application. The commutative ones of them ("*", "+") take ListE, while
  the others take plain lists.
- The tests now identify an additional issue, namely that repeated
  application of unary negation ("!") fails to parse.
