### PR TITLE
Let expression

### DIFF
--- a/Graphics/Implicit/ExtOpenScad/Eval/Expr.hs
+++ b/Graphics/Implicit/ExtOpenScad/Eval/Expr.hs
@@ -58,8 +58,8 @@ evalExpr' (ListE exprs) = do
     return $ \s -> OList $ map ($s) valFuncs
 
 evalExpr' (fexpr :$ argExprs) = do
-    fValFunc <- evalExpr' fexpr
     argValFuncs <- Monad.mapM evalExpr' argExprs
+    fValFunc <- evalExpr' fexpr
     return $ \s -> app (fValFunc s) (map ($s) argValFuncs)
         where 
             app f l = case (getErrors f, getErrors $ OList l) of

--- a/Graphics/Implicit/ExtOpenScad/Parser/Expr.hs
+++ b/Graphics/Implicit/ExtOpenScad/Parser/Expr.hs
@@ -42,6 +42,21 @@ exprN :: Integer -> GenParser Char st Expr
 
 exprN 12 =
          literal
+    *<|> "let expression" ?: do
+        _ <- string "let"
+        _ <- genSpace
+        _ <- string "("
+        _ <- sepBy (do 
+            _ <- genSpace
+            variable <- variableSymb
+            _ <- genSpace
+            _ <- string "="
+            _ <- genSpace
+            expr <- expr0
+            return $ LamE [Name variable] expr) (char ',' )
+        _ <- string ")"
+        expr <- expr0
+        return $ LamE [Name "asdf"] expr
     *<|> variable
     *<|> "bracketed expression" ?: do
         -- eg. ( 1 + 5 )

--- a/Graphics/Implicit/ExtOpenScad/Parser/Statement.hs
+++ b/Graphics/Implicit/ExtOpenScad/Parser/Statement.hs
@@ -37,8 +37,9 @@ computation =
         _ <- genSpace
         s <- tryMany [
             echo,
-            assignment,
-            include--,
+            include,
+            function,
+            assignment--,
             --use
             ]
         _ <- stringGS " ; "
@@ -107,9 +108,13 @@ assignment = ("assignment " ?:) $
         _ <- stringGS " = "
         valExpr <- expr0
         return $ StatementI line$ pattern := valExpr
-    *<|> do
+
+-- | A function declaration  (parser)
+function :: GenParser Char st StatementI
+function = ("function " ?:) $
+    do
         line <- lineNumber
-        varSymb <- (string "function" >> space >> genSpace >> variableSymb) 
+        varSymb <- (string "function" >> space >> genSpace >> variableSymb)
                    *<|> variableSymb
         _ <- stringGS " ( "
         argVars <- sepBy patternMatcher (stringGS " , ")
@@ -121,7 +126,7 @@ assignment = ("assignment " ?:) $
 echo :: GenParser Char st StatementI
 echo = do
     line <- lineNumber
-    _ <- stringGS " echo ( "
+    _ <- stringGS "echo ( "
     exprs <- expr0 `sepBy` (stringGS " , ")
     _ <- stringGS " ) "
     return $ StatementI line $ Echo exprs
@@ -146,7 +151,7 @@ forStatementI =
         --      for ( vsymb = vexpr   ) loops
         -- eg.  for ( a     = [1,2,3] ) {echo(a);   echo "lol";}
         -- eg.  for ( [a,b] = [[1,2]] ) {echo(a+b); echo "lol";}
-        _ <- stringGS " for ( "
+        _ <- stringGS "for ( "
         pattern <- patternMatcher
         _ <- stringGS " = "
         vexpr <- expr0

--- a/tests/ParserSpec/Expr.hs
+++ b/tests/ParserSpec/Expr.hs
@@ -30,6 +30,8 @@ logicalSpec = do
   describe "ternary operator" $ do
     specify "with primitive expressions" $
       "x ? 2 : 3" --> app' "?" [Var "x", num 2, num 3]
+    specify "with parenthesized comparison" $
+      "(1 > 0) ? 5 : -5" --> app' "?" [app' ">" [num 1, num 0], num 5, num (-5)]
     specify "with comparison in head position" $
       ternaryIssue $ "1 > 0 ? 5 : -5" --> app' "?" [app' ">" [num 1, num 0], num 5, num (-5)]
     specify "with comparison in head position, and addition in tail" $
@@ -46,6 +48,17 @@ literalSpec = do
     it "accepts true" $ "true" --> bool True
     it "accepts false" $ "false" --> bool False
 
+letBindingSpec :: Spec
+letBindingSpec = do
+    it "handles let with integer binding and spaces" $ do
+        "let ( a = 1 ) a" --> lambda' [Name "a"] (Var "a") [num 1]
+    it "handles multiple variable let" $ do
+        "let (a = x, b = y) a + b" --> lambda' [Name "a"] ((lambda' [Name "b"] (app "+" [Var "a", Var "b"])) [Var "y"]) [Var "x"]
+    it "handles empty let" $ do
+        "let () a" --> (Var "a")
+    it "handles nested let" $ do
+        "let(a=x) let(b = y) a + b" --> lambda' [Name "a"] ((lambda' [Name "b"] (app "+" [Var "a", Var "b"])) [Var "y"]) [Var "x"]
+    
 exprSpec :: Spec
 exprSpec = do
   describe "literals" literalSpec
@@ -99,3 +112,5 @@ exprSpec = do
     parseExpr "foo ++ bar ++ baz" `shouldBe`
     (Right $ app "++" [Var "foo", Var "bar", Var "baz"])
   describe "logical operators" logicalSpec
+  describe "let expressions" letBindingSpec
+  

--- a/tests/ParserSpec/Statement.hs
+++ b/tests/ParserSpec/Statement.hs
@@ -38,6 +38,9 @@ assignmentSpec = do
     "foo (x, y) = x * y;" `parsesAs` single fooFunction
   it "handles the function keyword" $
     "function foo(x, y) = x * y;" `parsesAs` single fooFunction
+  it "handles function with let expression" $
+    "function withlet(b) = let (c = 5) b + c;" `parsesAs` 
+    (single $ (Name "withlet" := LamE [Name "b"] (LamE [Name "c"] (Var "+" :$ [ListE [Var "b",Var "c"]]) :$ [num 5])))
   it "nested indexing" $
     "x = [y[0] - z * 2];" `parsesAs`
     (single $ Name "x" := ListE [app' "-" [app' "index" [Var "y", num 0],

--- a/tests/ParserSpec/Util.hs
+++ b/tests/ParserSpec/Util.hs
@@ -3,6 +3,7 @@ module ParserSpec.Util
        , bool
        , app
        , app'
+       , lambda'
        , parseWithEof
        , parseWithLeftOver
        , parseExpr
@@ -33,6 +34,9 @@ app name args = Var name :$ [ListE args]
 
 app' :: Symbol -> [Expr] -> Expr
 app' name args = Var name :$ args
+
+lambda' :: [Pattern] -> Expr -> [Expr] -> Expr
+lambda' params expr args = LamE params expr :$ args
 
 parseWithLeftOver :: Parser a -> String -> Either ParseError (a, String)
 parseWithLeftOver p = parse ((,) <$> p <*> leftOver) ""


### PR DESCRIPTION
Let expressions are part of the OpenSCAD language (in 2015.03, I don't know when they were added.)

They are useful in functions to enhance clarity of function expressions. They work in any expression context, but may have limited value outside functions. Regardless, OpenSCAD permits them in any expression, and so this change does the same.

The parser test suite (tests/Main.hs) has new tests for the change, and the whole parser test suite runs without errors.
