### PR TITLE
allowing negative arguments in scale()

### DIFF
--- a/Graphics/Implicit/ObjectUtil/GetBox2.hs
+++ b/Graphics/Implicit/ObjectUtil/GetBox2.hs
@@ -83,8 +83,10 @@ getBox2 (Translate2 v symbObj) =
 getBox2 (Scale2 s symbObj) =
     let
         (a,b) = getBox2 symbObj
+        (sax,say) = s ⋯* a
+        (sbx,sby) = s ⋯* b
     in
-        (s ⋯* a, s ⋯* b)
+        ((min sax sbx, min say sby), (max sax sbx, max say sby))
 
 getBox2 (Rotate2 θ symbObj) = 
     let

--- a/Graphics/Implicit/ObjectUtil/GetBox3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetBox3.hs
@@ -72,8 +72,10 @@ getBox3 (Translate3 v symbObj) =
 getBox3 (Scale3 s symbObj) =
     let
         (a,b) = getBox3 symbObj
+        (sax,say,saz) = s ⋯* a
+        (sbx,sby,sbz) = s ⋯* b
     in
-        (s ⋯* a, s ⋯* b)
+        ((min sax sbx, min say sby, min saz sbz), (max sax sbx, max say sby, max saz sbz))
 getBox3 (Rotate3 _ symbObj) = ( (-d, -d, -d), (d, d, d) )
     where
         ((x1,y1, z1), (x2,y2, z2)) = getBox3 symbObj

--- a/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
@@ -79,7 +79,7 @@ getImplicit3 (Translate3 v symbObj) =
 getImplicit3 (Scale3 s@(sx,sy,sz) symbObj) =
     let
         obj = getImplicit3 symbObj
-        k = (sx*sy*sz)**(1/3)
+        k = abs(sx*sy*sz)**(1/3)
     in
         \p -> k * obj (p ⋯/ s)
 


### PR DESCRIPTION
because I was missing a mirror() command, I added a simple patch to scale() to allow negative scale arguments/factors.

so I could write

```
scale([-1,1,1]) cube([10,10,10]);
```

where I need

```
mirror([1,0,0])cube([10,10,10]);
```
