### PR TITLE
Fix openscad-export of cylinder

### DIFF
--- a/Graphics/Implicit/Export/SymbolicFormats.hs
+++ b/Graphics/Implicit/Export/SymbolicFormats.hs
@@ -55,7 +55,7 @@ buildS3 (Rect3R r (x1,y1,z1) (x2,y2,z2)) | r == 0 = call "translate" [bf x1, bf 
 
 buildS3 (Sphere r) = callNaked "sphere" ["r = " <> bf r] []
 
-buildS3 (Cylinder h r1 r2) = call "cylinder" [
+buildS3 (Cylinder h r1 r2) = callNaked "cylinder" [
                               "r1 = " <> bf r1
                              ,"r2 = " <> bf r2
                              , bf h


### PR DESCRIPTION
Hi,

Fix cylinder-export for openscad.
Current openscad-export makes syntax-error for openscad.

See http://www.openscad.org/cheatsheet/index.html.
Crylinder syntax does not use list([ .. ]).
So, this PR fixes it.
