### PR TITLE
Fix function-definition-test

### DIFF
--- a/tests/ParserSpec/Statement.hs
+++ b/tests/ParserSpec/Statement.hs
@@ -34,9 +34,7 @@ assignmentSpec = do
   it "handles pattern matching" $
     "[x, y] = [1, 2];" `parsesAs`
     (single $ ListP [Name "x", Name "y"] := (ListE [num 1, num 2]))
-  it "handles function definitions" $
-    "foo (x, y) = x * y;" `parsesAs` single fooFunction
-  it "handles the function keyword" $
+  it "handles the function keyword and definitions" $
     "function foo(x, y) = x * y;" `parsesAs` single fooFunction
   it "nested indexing" $
     "x = [y[0] - z * 2];" `parsesAs`


### PR DESCRIPTION
Hi.

Current function-defintion test always fails.
The error message is below.
I wonder function-definition needs ```function```-keyword.

```
      assignment
        parses correctly
        handles pattern matching
        handles function definitions FAILED [1]
        handles the function keyword
        nested indexing
      if
        parses
    
    Failures:
    
      tests/ParserSpec/Statement.hs:12: 
      1) statements.assignment handles function definitions
           expected: Right [StatementI 1 (Name "foo" := LamE [Name "x",Name "y"] (Var "*" :$ [ListE [Var "x",Var "y"]]))]
            but got: Left "src" (line 1, column 12):
                     unexpected "="
                     expecting "//", "/*",  suite or ";"
```
