### PR TITLE
Update stack LTS

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/master/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-3.12
+resolver: lts-9.8
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
Use stack LTS 9.8 for GHC 8.0.2

Tested using stack test, which produces the same error with and without the patch.

"40 examples, 1 failure, 4 pending"

The new LTS version builds without running 'stack solver --update-config'  to update the extra-deps section in the stack.yaml file.