### PR TITLE
Remove 'download' from dependencies.

### DIFF
--- a/implicit.cabal
+++ b/implicit.cabal
@@ -20,7 +20,6 @@ library
         base >= 3 && < 5,
         filepath,
         directory,
-        download,
         parsec,
         unordered-containers,
         parallel,


### PR DESCRIPTION
This fixes a setup issue when using `cabal install` on Windows where it can't find a C compiler for `old-time` (via `feed` via `download`).