### PR TITLE
fix build errors on OS X

### DIFF
--- a/programs/extopenscad.hs
+++ b/programs/extopenscad.hs
@@ -88,7 +88,7 @@ formatExtensions =
 -- Lookup an output format for a given output file. Throw an error if one cannot be found.
 guessOutputFormat :: FilePath -> OutputFormat
 guessOutputFormat fileName =
-    maybe (error $ "Unrecognized output format: "<>ext) id
+    maybe (error $ "Unrecognized output format: "Main.<>ext) id
     $ readOutputFormat $ tail ext
     where
         (_,ext) = splitExtension fileName
@@ -99,30 +99,30 @@ extOpenScadOpts = ExtOpenScadOpts
     <$> optional (
       strOption
         (  short 'o'
-        <> long "output"
-        <> metavar "FILE"
-        <> help "Output file name"
+        Main.<> long "output"
+        Main.<> metavar "FILE"
+        Main.<> help "Output file name"
         )
       )
     <*> optional (
       option auto
         (  short 'f'
-        <> long "format"
-        <> metavar "FORMAT"
-        <> help "Output format"
+        Main.<> long "format"
+        Main.<> metavar "FORMAT"
+        Main.<> help "Output format"
         )
       )
     <*> optional (
       option auto
         (  short 'r'
-        <> long "resolution"
-        <> metavar "RES"
-        <> help "Approximation quality (smaller is better)"
+        Main.<> long "resolution"
+        Main.<> metavar "RES"
+        Main.<> help "Approximation quality (smaller is better)"
         )
       )
     <*> argument str
         (  metavar "FILE"
-        <> help "Input extended OpenSCAD file"
+        Main.<> help "Input extended OpenSCAD file"
         )
 
 -- Try to look up an output format from a supplied extension.
@@ -174,7 +174,7 @@ export3 posFmt res output obj =
         Just OBJ  -> writeOBJ res output obj
         Just PNG  -> writePNG3 res output obj
         Nothing   -> writeBinSTL res output obj
-        Just fmt  -> putStrLn $ "Unrecognized 3D format: "<>show fmt
+        Just fmt  -> putStrLn $ "Unrecognized 3D format: "Main.<>show fmt
 
 -- Output a file containing a 2D object.
 export2 :: Maybe OutputFormat -> ℝ -> FilePath -> SymbolicObj2 -> IO ()
@@ -185,7 +185,7 @@ export2 posFmt res output obj =
         Just PNG   -> writePNG2 res output obj
         Just GCode -> writeGCodeHacklabLaser res output obj
         Nothing    -> writeSVG res output obj
-        Just fmt   -> putStrLn $ "Unrecognized 2D format: "<>show fmt
+        Just fmt   -> putStrLn $ "Unrecognized 2D format: "Main.<>show fmt
 
 -- Interpret arguments, and render the object defined in the supplied input file.
 run :: ExtOpenScadOpts -> IO()
@@ -238,6 +238,6 @@ main = execParser opts >>= run
     where
         opts= info (helper <*> extOpenScadOpts)
               ( fullDesc
-              <> progDesc "ImplicitCAD: Extended OpenSCAD interpreter." 
-              <> header "extopenscad - Extended OpenSCAD"
+              Main.<> progDesc "ImplicitCAD: Extended OpenSCAD interpreter." 
+              Main.<> header "extopenscad - Extended OpenSCAD"
               )


### PR DESCRIPTION
When following the build instructions on the website for OS X I run into a ton of these:

```sh
programs/extopenscad.hs:242:15: error:
    Ambiguous occurrence ‘<>’
    It could refer to either ‘Prelude.<>’,
                             imported from ‘Prelude’ at programs/extopenscad.hs:1:1
                             (and originally defined in ‘GHC.Base’)
                          or ‘Main.<>’, defined at programs/extopenscad.hs:54:1
    |
242 |               <> header "extopenscad - Extended OpenSCAD"
    |               ^^
cabal: Leaving directory '.'
cabal: Error: some packages failed to install:
implicit-0.1.0-58HVBI6UA39IG2sPxTri8I failed during the building phase. The
exception was:
ExitFailure 1
```

(full log available [here](https://gist.github.com/sbma44/7d73077663f4657546a856b48dbd1abe))

![image](https://user-images.githubusercontent.com/31717/38744382-b2545188-3f0f-11e8-854e-96135f2634bd.png)

**I don't know anything about Haskell.** On the other hand, the fact that I installed everything from scratch means that I'm pretty sure these errors aren't a legacy of anything weird about my Haskell dev environment.

After adding some scoping to these references things seem to work -- `cabal install` succeeds and the resulting binary can be run without segfaulting or anything else weird happening (EDIT: the circle hello world  SVG demo works, too). My guess is that the march of Haskell-progress has deprecated and then retired some default ambiguity-resolving behavior. Time makes fools of us all!