### PR TITLE
Bump to stackage lts 13.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 dist/
 Setup
 docs/iscad.md
+.stack-work/

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,15 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/master/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-9.8
+resolver: lts-13.12
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+- storable-endian-0.2.6
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
This compiles.  Two tests fail but I doubt the stackage version has anything to do with it.  


Here are the failing tests, anyway:

```
  tests/ParserSpec/Statement.hs:27:5: 
  1) statements.if parses
       expected: Right [StatementI 1 1 (If (LitE True) [StatementI 1 1 (ModuleCall "a" [] [])] [StatementI 1 1 (ModuleCall "b" [] [])])]
        but got: Right [StatementI 1 1 (If (LitE True) [StatementI 1 13 (ModuleCall "a" [] [])] [StatementI 1 27 (ModuleCall "b" [] [])])]

  To rerun use: --match "/statements/if/parses/"

  tests/ParserSpec/Statement.hs:27:5: 
  2) statements, difference of two cylinders, parses correctly
       expected: Right [StatementI 1 1 (ModuleCall "difference" [] [StatementI 1 1 (ModuleCall "cylinder" [(Just "r",LitE 5.0),(Just "h",LitE 20.0)] []),StatementI 1 1 (ModuleCall "cylinder" [(Just "r",LitE 2.0),(Just "h",LitE 20.0)] [])])]
        but got: Right [StatementI 1 1 (ModuleCall "difference" [] [StatementI 1 15 (ModuleCall "cylinder" [(Just "r",LitE 5.0),(Just "h",LitE 20.0)] []),StatementI 1 35 (ModuleCall "cylinder" [(Just "r",LitE 2.0),(Just "h",LitE 20.0)] [])])]
```