### PR TITLE
Fixed cube implicit arg in openscad parser

### DIFF
--- a/Graphics/Implicit/ExtOpenScad/Primitives.hs
+++ b/Graphics/Implicit/ExtOpenScad/Primitives.hs
@@ -80,10 +80,6 @@ cube = moduleWithoutSuite "cube" $ do
     -- examples
     example "cube(size = [2,3,4], center = true, r = 0.5);"
     example "cube(4);"
-    -- arguments shared between forms
-    r      :: ℝ    <- argument "r"
-                        `doc` "radius of rounding"
-                        `defaultTo` 0
     -- arguments (two forms)
     ((x1,x2), (y1,y2), (z1,z2)) <-
         do
@@ -110,10 +106,16 @@ cube = moduleWithoutSuite "cube" $ do
                 `defaultTo` False
             let (x,y, z) = either (\w -> (w,w,w)) id size
             return (toInterval center x, toInterval center y, toInterval center z)
+    -- arguments shared between forms
+    r      :: ℝ    <- argument "r"
+                        `doc` "radius of rounding"
+                        `defaultTo` 0
     -- Tests
     test "cube(4);"
         `eulerCharacteristic` 2
     test "cube(size=[2,3,4]);"
+        `eulerCharacteristic` 2
+    test "cube([2,3,4]);" -- openscad syntax
         `eulerCharacteristic` 2
     addObj3 $ Prim.rect3R r (x1, y1, z1) (x2, y2, z2)
 


### PR DESCRIPTION
fixes https://github.com/colah/ImplicitCAD/issues/216
added a test case just in case, but it doesn't seem to be ran at all