### PR TITLE
mess with runtime parameters

### DIFF
--- a/implicit.cabal
+++ b/implicit.cabal
@@ -130,6 +130,7 @@ Executable extopenscad
 --               -dynamic
                -- see GHC manual 8.2.1 section 6.5.1.
                -feager-blackholing
+               -with-rtsopts=-N256               
                -- for debugging.
                -Wall
                -Wcompat
@@ -189,6 +190,7 @@ Executable implicitsnap
 --               -dynamic
                -- see GHC manual 8.2.1 section 6.5.1.
                -feager-blackholing
+               -with-rtsopts=-N256
                -- for debugging.
                -Wall
                -Wcompat


### PR DESCRIPTION
Not sure about this.  I understand from [ghc user manual](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/using-concurrent.html#rts-flag--N%20%E2%9F%A8x%E2%9F%A9) that ghc will look at the number of cores available and limit both to 256 *and* that number, but I haven't tested it.