### PR TITLE
Support XY-scaling on linear_extrude (resolves #268)

### DIFF
--- a/Graphics/Implicit.hs
+++ b/Graphics/Implicit.hs
@@ -33,7 +33,7 @@ import Graphics.Implicit.Primitives as P (translate, scale, complement, union, i
 import Graphics.Implicit.ExtOpenScad as E (runOpenscad)
 
 -- typesclasses and types defining the world, or part of the world.
-import Graphics.Implicit.Definitions as W (ℝ, SymbolicObj2, SymbolicObj3)
+import Graphics.Implicit.Definitions as W (ℝ, SymbolicObj2, SymbolicObj3, ExtrudeRMScale(C1, C2, Fn))
 
 -- Functions for writing files based on the result of operations on primitives.
 import qualified Graphics.Implicit.Export as Export (writeSVG, writeDXF2, writeSTL, writeBinSTL, writeOBJ, writeSCAD2, writeSCAD3, writeTHREEJS, writeGCodeHacklabLaser, writePNG)

--- a/Graphics/Implicit/Export/SymbolicFormats.hs
+++ b/Graphics/Implicit/Export/SymbolicFormats.hs
@@ -10,7 +10,7 @@ module Graphics.Implicit.Export.SymbolicFormats (scad2, scad3) where
 
 import Prelude(Either(Left, Right), ($), (*), ($!), (-), (/), pi, error, (+), (==), take, floor, (&&), const, pure, (<>), sequenceA, (<$>))
 
-import Graphics.Implicit.Definitions(ℝ, SymbolicObj2(RectR, Circle, PolygonR, Complement2, UnionR2, DifferenceR2, IntersectR2, Translate2, Scale2, Rotate2, Outset2, Shell2, EmbedBoxedObj2), SymbolicObj3(Rect3R, Sphere, Cylinder, Complement3, UnionR3, IntersectR3, DifferenceR3, Translate3, Scale3, Rotate3, Rotate3V, Outset3, Shell3, ExtrudeR, ExtrudeRotateR, ExtrudeRM, EmbedBoxedObj3, RotateExtrude, ExtrudeOnEdgeOf))
+import Graphics.Implicit.Definitions(ℝ, SymbolicObj2(RectR, Circle, PolygonR, Complement2, UnionR2, DifferenceR2, IntersectR2, Translate2, Scale2, Rotate2, Outset2, Shell2, EmbedBoxedObj2), SymbolicObj3(Rect3R, Sphere, Cylinder, Complement3, UnionR3, IntersectR3, DifferenceR3, Translate3, Scale3, Rotate3, Rotate3V, Outset3, Shell3, ExtrudeR, ExtrudeRotateR, ExtrudeRM, EmbedBoxedObj3, RotateExtrude, ExtrudeOnEdgeOf), isScaleID)
 import Graphics.Implicit.Export.TextBuilderUtils(Text, Builder, toLazyText, fromLazyText, bf)
 
 import Control.Monad.Reader (Reader, runReader, ask)
@@ -91,7 +91,7 @@ buildS3 (ExtrudeR r obj h) | r == 0 = callNaked "linear_extrude" ["height = " <>
 buildS3 (ExtrudeRotateR r twist obj h) | r == 0 = callNaked "linear_extrude" ["height = " <> bf h, "twist = " <> bf twist] [buildS2 obj]
 
 -- FIXME: handle scale, center.
-buildS3 (ExtrudeRM r twist (Left scale) (Left translate) obj (Left height)) | r == 0 && scale == 1 && translate == (0,0) = do
+buildS3 (ExtrudeRM r twist scale (Left translate) obj (Left height)) | r == 0 && isScaleID scale && translate == (0,0) = do
   res <- ask
   let
     twist' = case twist of

--- a/Graphics/Implicit/ExtOpenScad/Primitives.hs
+++ b/Graphics/Implicit/ExtOpenScad/Primitives.hs
@@ -17,7 +17,7 @@ module Graphics.Implicit.ExtOpenScad.Primitives (primitiveModules) where
 
 import Prelude(Either(Left, Right), Bool(True, False), Maybe(Just, Nothing), ($), pure, either, id, (-), (==), (&&), (<), (*), cos, sin, pi, (/), (>), const, uncurry, fromInteger, round, (/=), (||), not, null, fmap, (<>), otherwise)
 
-import Graphics.Implicit.Definitions (ℝ, ℝ2, ℝ3, ℕ, SymbolicObj2, SymbolicObj3, fromℕtoℝ)
+import Graphics.Implicit.Definitions (ℝ, ℝ2, ℝ3, ℕ, SymbolicObj2, SymbolicObj3, ExtrudeRMScale(C1), fromℕtoℝ, isScaleID)
 
 import Graphics.Implicit.ExtOpenScad.Definitions (OVal (OObj2, OObj3, ONModule), ArgParser, Symbol(Symbol), StateC, SourcePosition)
 
@@ -428,7 +428,7 @@ extrude = moduleWithSuite "linear_extrude" $ \_ children -> do
         `doc` "center? (the z component)"
     twistArg  :: Either ℝ (ℝ  -> ℝ) <- argument "twist"  `defaultTo` Left 0
         `doc` "twist as we extrude, either a total amount to twist or a function..."
-    scaleArg  :: Either ℝ (ℝ  -> ℝ) <- argument "scale"  `defaultTo` Left 1
+    scaleArg  :: ExtrudeRMScale <- argument "scale"  `defaultTo` C1 1
         `doc` "scale according to this funciton as we extrude..."
     translateArg :: Either ℝ2 (ℝ -> ℝ2) <- argument "translate"  `defaultTo` Left (0,0)
         `doc` "translate according to this funciton as we extrude..."
@@ -450,15 +450,12 @@ extrude = moduleWithSuite "linear_extrude" $ \_ children -> do
         isTwistID = case twistArg of
                       Left constant -> constant == 0
                       Right _       -> False
-        isScaleID = case scaleArg of
-                      Left constant -> constant == 1
-                      Right _       -> False
         isTransID = case translateArg of
                       Left constant -> constant == (0,0)
                       Right _       -> False
     pure $ pure $ obj2UpMap (
         \obj -> case height of
-            Left constHeight | isTwistID && isScaleID && isTransID ->
+            Left constHeight | isTwistID && isScaleID scaleArg && isTransID ->
                 shiftAsNeeded $ Prim.extrudeR r obj constHeight
             _ ->
                 shiftAsNeeded $ Prim.extrudeRM r twistArg scaleArg translateArg obj height'

--- a/Graphics/Implicit/ExtOpenScad/Util/OVal.hs
+++ b/Graphics/Implicit/ExtOpenScad/Util/OVal.hs
@@ -16,7 +16,7 @@ module Graphics.Implicit.ExtOpenScad.Util.OVal(OTypeMirror, (<||>), fromOObj, to
 
 import Prelude(Maybe(Just, Nothing), Bool(True, False), Either(Left,Right), (==), fromInteger, floor, ($), (.), fmap, error, (<>), show, flip, filter, not, return)
 
-import Graphics.Implicit.Definitions(ℝ, ℕ, SymbolicObj2, SymbolicObj3, fromℕtoℝ)
+import Graphics.Implicit.Definitions(ℝ, ℝ2, ℕ, SymbolicObj2, SymbolicObj3, ExtrudeRMScale(C1, C2, Fn), fromℕtoℝ)
 
 import Graphics.Implicit.ExtOpenScad.Definitions (OVal(ONum, OBool, OString, OList, OFunc, OUndefined, OUModule, ONModule, OVargsModule, OError, OObj2, OObj3))
 
@@ -117,6 +117,16 @@ instance (OTypeMirror a, OTypeMirror b) => OTypeMirror (Either a b) where
 
     toOObj (Right x) = toOObj x
     toOObj (Left  x) = toOObj x
+
+instance OTypeMirror ExtrudeRMScale where
+    fromOObj (fromOObj -> Just (x :: ℝ)) = Just $ C1 x
+    fromOObj (fromOObj -> Just (x :: ℝ2)) = Just $ C2 x
+    fromOObj (fromOObj -> Just (x :: (ℝ -> Either ℝ ℝ2))) = Just $ Fn x
+    fromOObj _ = Nothing
+
+    toOObj (C1 x) = toOObj x
+    toOObj (C2 x) = toOObj x
+    toOObj (Fn x) = toOObj x
 
 -- A string representing each type.
 oTypeStr :: OVal -> Text

--- a/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
@@ -10,7 +10,7 @@ import Prelude (Either(Left, Right), abs, (-), (/), (*), sqrt, (+), atan2, max, 
 import Graphics.Implicit.Definitions (ℝ, ℕ, ℝ2, ℝ3, (⋯/), Obj3,
                                       SymbolicObj3(Shell3, UnionR3, IntersectR3, DifferenceR3, Translate3, Scale3, Rotate3,
                                                    Outset3, Rect3R, Sphere, Cylinder, Complement3, EmbedBoxedObj3, Rotate3V,
-                                                   ExtrudeR, ExtrudeRM, ExtrudeOnEdgeOf, RotateExtrude, ExtrudeRotateR), fromℕtoℝ, (⋅), minℝ)
+                                                   ExtrudeR, ExtrudeRM, ExtrudeOnEdgeOf, RotateExtrude, ExtrudeRotateR), fromℕtoℝ, toScaleFn, (⋅), minℝ)
 
 import Graphics.Implicit.MathUtil (rmaximum, rminimum, rmax)
 
@@ -139,13 +139,9 @@ getImplicit3 (ExtrudeRM r twist scale translate symbObj height) =
             (xTrans, yTrans) = case trans of
                                  Left  tval -> tval
                                  Right tfun -> tfun z
-        scaleVec :: Either ℝ (ℝ -> ℝ) -> ℝ -> ℝ2 -> ℝ2
-        scaleVec scale' s (x,y) =
-          case scale' of
-            Left sval  -> if sval == 1
-                          then (x,y)
-                          else (x/sval    , y/sval)
-            Right sfun ->      (x/sfun s, y/sfun s)
+        scaleVec :: ℝ -> ℝ2 -> ℝ2
+        scaleVec z (x, y) = let (sx, sy) = toScaleFn scale z
+                            in  (x / sx, y / sy)
         rotateVec :: ℝ -> ℝ2 -> ℝ2
         rotateVec θ (x,y)
           | θ == 0    = (x,y)
@@ -159,7 +155,7 @@ getImplicit3 (ExtrudeRM r twist scale translate symbObj height) =
             res = rmax r
                 (obj
                  . rotateVec (-k*twistVal twist z h)
-                 . scaleVec scale z
+                 . scaleVec z
                  . translatePos translate z
                  $ (x,y))
                 (abs (z - h/2) - h/2)

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -74,7 +74,8 @@ import Graphics.Implicit.Definitions (ℝ, ℝ2, ℝ3, Box2,
                                                    ExtrudeRM,
                                                    RotateExtrude,
                                                    ExtrudeOnEdgeOf
-                                                  )
+                                                  ),
+                                      ExtrudeRMScale
                                      )
 import Graphics.Implicit.MathUtil   (pack)
 import Graphics.Implicit.ObjectUtil (getBox2, getBox3, getImplicit2, getImplicit3)
@@ -245,7 +246,7 @@ extrudeRotateR = ExtrudeRotateR
 
 extrudeRM :: ℝ
     -> Either ℝ (ℝ -> ℝ)
-    -> Either ℝ (ℝ -> ℝ)
+    -> ExtrudeRMScale
     -> Either ℝ2 (ℝ -> ℝ2)
     -> SymbolicObj2
     -> Either ℝ (ℝ2 -> ℝ)

--- a/programs/Benchmark.hs
+++ b/programs/Benchmark.hs
@@ -12,7 +12,7 @@ import Prelude (($), (*), (/), String, IO, cos, pi, fmap, zip3, Either(Left, Rig
 import Criterion.Main (Benchmark, bgroup, bench, nf, nfAppIO, defaultMain)
 
 -- The parts of ImplicitCAD we know how to benchmark.
-import Graphics.Implicit (union, circle, sphere, SymbolicObj2, SymbolicObj3, writeDXF2, writeSVG, writePNG2, writeSTL, writeBinSTL, unionR, translate, difference, extrudeRM, rect3R)
+import Graphics.Implicit (union, circle, sphere, SymbolicObj2, SymbolicObj3, ExtrudeRMScale(C1), writeDXF2, writeSVG, writePNG2, writeSTL, writeBinSTL, unionR, translate, difference, extrudeRM, rect3R)
 import Graphics.Implicit.Export.SymbolicObj2 (symbolicGetContour)
 import Graphics.Implicit.Export.SymbolicObj3 (symbolicGetMesh)
 
@@ -36,7 +36,7 @@ obj2d_1 =
 
 -- | An extruded version of obj2d_1, should be identical to the website's example, and example5.escad.
 object1 :: SymbolicObj3
-object1 = extrudeRM 0 (Right twist) (Left 1) (Left (0,0)) obj2d_1 (Left 40)
+object1 = extrudeRM 0 (Right twist) (C1 1) (Left (0,0)) obj2d_1 (Left 40)
     where
       twist :: ℝ -> ℝ
       twist h = 35*cos(h*2*pi/60)


### PR DESCRIPTION
This pull request resolves #268.

The scale parameter of `linear_extrude` now supports `(ℝ, ℝ)` and `ℝ -> (ℝ, ℝ)` in addition to `ℝ` and `ℝ -> ℝ`. This allows `x` and `y` to be scaled independently from each other while extruding.

Example demonstrating all 4 variants:
```
union() {
    linear_extrude(height = 10, scale = 2)
    square(10, center = true);

    translate([30, 0, 0])
    linear_extrude(height = 10, scale(z) = 1 + z / 10)
    square(10, center = true);
    
    translate([0, 30, 0])
    linear_extrude(height = 10, scale = [2, 1.5])
    square(10, center = true);
    
    translate([30, 30, 0])
    linear_extrude(height = 10, scale(z) = [1 + z / 10, 1 + z / 20])
    square(10, center = true);
}
```

Feedback and suggestions welcome.