### PR TITLE
Add nix support files

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,7 @@
+{ pkgs ? import <nixpkgs> {}, withImplicitSnap ? false }:
+let
+  src = pkgs.nix-gitignore.gitignoreSource [ ] ./.;
+in
+  if withImplicitSnap
+  then pkgs.haskellPackages.callCabal2nixWithOptions "implicit" src "-fimplicitsnap" { }
+  else pkgs.haskellPackages.callCabal2nix "implicit" src { }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,2 @@
+{ pkgs ? import <nixpkgs> {}, withImplicitSnap ? true }:
+(import ./default.nix { inherit pkgs withImplicitSnap; }).env


### PR DESCRIPTION
`default.nix` for building the project with `nix-build` using systems
`<nixpkgs>` and default compiler.

`shell.nix` to allow usage of `nix-shell` to enter development shell.

`default.nix` uses `withImplicitSnap = false` default.

To build with `implicitsnap` use

```
nix-build --arg withImplicitSnap true
```

`shell.nix` enables `withImplicitSnap` by default and can be overriden with

```
nix-shell --arg withImplicitSnap false
```