### PR TITLE
Fix vertex coordinates in obj output

### DIFF
--- a/Graphics/Implicit/Export/Util.hs
+++ b/Graphics/Implicit/Export/Util.hs
@@ -21,7 +21,7 @@ default (ℝ)
 -- FIXME: magic numbers.
 normTriangle :: ℝ -> Obj3 -> Triangle -> NormedTriangle
 normTriangle res obj (Triangle (a,b,c)) =
-    NormedTriangle (normify a', normify b', normify c')
+    NormedTriangle ((a, normify a'), (b, normify b'), (c, normify c'))
         where
             normify = normVertex res obj
             a' = (a ^+^ r*^b ^+^ r*^c) ^/ 1.02
@@ -31,7 +31,7 @@ normTriangle res obj (Triangle (a,b,c)) =
             r = 0.01
 
 -- FIXME: magic numbers.
-normVertex :: ℝ -> Obj3 -> ℝ3 -> (ℝ3, ℝ3)
+normVertex :: ℝ -> Obj3 -> ℝ3 -> ℝ3
 normVertex res obj p =
     let
         -- D_vf(p) = ( f(p) - f(p+v) ) /|v|
@@ -44,7 +44,7 @@ normVertex res obj p =
         dx = d (1, 0, 0)
         dy = d (0, 1, 0)
         dz = d (0, 0, 1)
-    in (p, normalized (dx,dy,dz))
+    in normalized (dx,dy,dz)
 
 -- Get a centroid of a series of points.
 centroid :: (VectorSpace v, Fractional (Scalar v)) => [v] -> v


### PR DESCRIPTION
Now preserves vertex coordinates and only uses adjusted
coords for vertex normal computation.

Magic numbers adjustment seems to be needed for corner cases
when computing derivatives.

Meshlab comparison (left STL, right OBJ) - http://48.io/~rmarko/2020-10-25-202749_1920x1080_scrot.png

With the fix `asciistl` and `obj` outputs contain exactly the same coords (except for normals).
