### PR TITLE
Improve haddock of Graphics.Implicit

### DIFF
--- a/Graphics/Implicit.hs
+++ b/Graphics/Implicit.hs
@@ -184,6 +184,10 @@ writePNG2
     -> IO ()
 writePNG2 = Export.writePNG
 
+
+-- | Export a PNG of the 'SymbolicObj3'. The projection is with a front-facing
+-- camera, so the coordinate system is @(left to right, front to back, down to
+-- up)@.
 writePNG3
     :: ℝ  -- ^ Rendering resolution, in millimeters. Smaller values produce
           -- exports more faithful to the implicit model, at the expense of

--- a/Graphics/Implicit.hs
+++ b/Graphics/Implicit.hs
@@ -53,7 +53,6 @@ module Graphics.Implicit (
   -- * Extrusions into 3D
   P.extrudeR,
   P.extrudeRM,
-  P.extrudeRotateR,
   P.extrudeOnEdgeOf,
   P.rotateExtrude,
 
@@ -80,7 +79,7 @@ import Prelude(FilePath, IO)
 
 -- The primitive objects, and functions for manipulating them.
 -- MAYBEFIXME: impliment slice operation, regularPolygon and zsurface primitives.
-import Graphics.Implicit.Primitives as P (translate, scale, complement, union, intersect, difference, unionR, intersectR, differenceR, shell, extrudeR, extrudeRM, extrudeRotateR, extrudeOnEdgeOf, sphere, rect3R, circle, cylinder, cylinder2, rectR, polygonR, rotateExtrude, rotate3, rotate3V, pack3, rotate, pack2, implicit, Object)
+import Graphics.Implicit.Primitives as P (translate, scale, complement, union, intersect, difference, unionR, intersectR, differenceR, shell, extrudeR, extrudeRM, extrudeOnEdgeOf, sphere, rect3R, circle, cylinder, cylinder2, rectR, polygonR, rotateExtrude, rotate3, rotate3V, pack3, rotate, pack2, implicit, Object)
 
 -- The Extended OpenScad interpreter.
 import Graphics.Implicit.ExtOpenScad as E (runOpenscad)

--- a/Graphics/Implicit.hs
+++ b/Graphics/Implicit.hs
@@ -27,7 +27,7 @@ import Prelude(FilePath, IO)
 
 -- The primitive objects, and functions for manipulating them.
 -- MAYBEFIXME: impliment slice operation, regularPolygon and zsurface primitives.
-import Graphics.Implicit.Primitives as P (translate, scale, complement, union, intersect, difference, unionR, intersectR, differenceR, shell, extrudeR, extrudeRM, extrudeRotateR, extrudeOnEdgeOf, sphere, rect3R, circle, cylinder, cylinder2, rectR, polygonR, rotateExtrude, rotate3, rotate3V, pack3, rotate, pack2, implicit)
+import Graphics.Implicit.Primitives as P (translate, scale, complement, union, intersect, difference, unionR, intersectR, differenceR, shell, extrudeR, extrudeRM, extrudeRotateR, extrudeOnEdgeOf, sphere, rect3R, circle, cylinder, cylinder2, rectR, polygonR, rotateExtrude, rotate3, rotate3V, pack3, rotate, pack2, implicit, Object)
 
 -- The Extended OpenScad interpreter.
 import Graphics.Implicit.ExtOpenScad as E (runOpenscad)

--- a/Graphics/Implicit.hs
+++ b/Graphics/Implicit.hs
@@ -41,36 +41,102 @@ import qualified Graphics.Implicit.Export as Export (writeSVG, writeDXF2, writeS
 -- We want Export to be a bit less polymorphic
 -- (so that types will collapse nicely)
 
-writeSVG :: ℝ -> FilePath -> SymbolicObj2 -> IO ()
+writeSVG
+    :: ℝ  -- ^ Rendering resolution, in millimeters. Smaller values produce
+          -- exports more faithful to the implicit model, at the expense of
+          -- taking /O(n^-2)/ more time.
+    -> FilePath
+    -> SymbolicObj2
+    -> IO ()
 writeSVG = Export.writeSVG
 
-writeDXF2 :: ℝ -> FilePath -> SymbolicObj2 -> IO ()
+writeDXF2
+    :: ℝ  -- ^ Rendering resolution, in millimeters. Smaller values produce
+          -- exports more faithful to the implicit model, at the expense of
+          -- taking /O(n^-2)/ more time.
+    -> FilePath
+    -> SymbolicObj2
+    -> IO ()
 writeDXF2 = Export.writeDXF2
 
-writeSTL :: ℝ -> FilePath -> SymbolicObj3 -> IO ()
+writeSTL
+    :: ℝ  -- ^ Rendering resolution, in millimeters. Smaller values produce
+          -- exports more faithful to the implicit model, at the expense of
+          -- taking /O(n^-3)/ more time.
+    -> FilePath
+    -> SymbolicObj3
+    -> IO ()
 writeSTL = Export.writeSTL
 
-writeBinSTL :: ℝ -> FilePath -> SymbolicObj3 -> IO ()
+writeBinSTL
+    :: ℝ  -- ^ Rendering resolution, in millimeters. Smaller values produce
+          -- exports more faithful to the implicit model, at the expense of
+          -- taking /O(n^-3)/ more time.
+    -> FilePath
+    -> SymbolicObj3
+    -> IO ()
 writeBinSTL = Export.writeBinSTL
 
-writeOBJ :: ℝ -> FilePath -> SymbolicObj3 -> IO ()
+writeOBJ
+    :: ℝ  -- ^ Rendering resolution, in millimeters. Smaller values produce
+          -- exports more faithful to the implicit model, at the expense of
+          -- taking /O(n^-3)/ more time.
+    -> FilePath
+    -> SymbolicObj3
+    -> IO ()
 writeOBJ = Export.writeOBJ
 
-writeSCAD2 :: ℝ -> FilePath -> SymbolicObj2 -> IO ()
+writeSCAD2
+    :: ℝ  -- ^ Rendering resolution, in millimeters. Smaller values produce
+          -- exports more faithful to the implicit model, at the expense of
+          -- taking /O(n^-2)/ more time.
+    -> FilePath
+    -> SymbolicObj2
+    -> IO ()
 writeSCAD2 = Export.writeSCAD2
 
-writeSCAD3 :: ℝ -> FilePath -> SymbolicObj3 -> IO ()
+writeSCAD3
+    :: ℝ  -- ^ Rendering resolution, in millimeters. Smaller values produce
+          -- exports more faithful to the implicit model, at the expense of
+          -- taking /O(n^-3)/ more time.
+    -> FilePath
+    -> SymbolicObj3
+    -> IO ()
 writeSCAD3 = Export.writeSCAD3
 
-writeTHREEJS :: ℝ -> FilePath -> SymbolicObj3 -> IO ()
+writeTHREEJS
+    :: ℝ  -- ^ Rendering resolution, in millimeters. Smaller values produce
+          -- exports more faithful to the implicit model, at the expense of
+          -- taking /O(n^-3)/ more time.
+    -> FilePath
+    -> SymbolicObj3
+    -> IO ()
 writeTHREEJS = Export.writeTHREEJS
 
-writeGCodeHacklabLaser :: ℝ -> FilePath -> SymbolicObj2 -> IO ()
+writeGCodeHacklabLaser
+    :: ℝ  -- ^ Rendering resolution, in millimeters. Smaller values produce
+          -- exports more faithful to the implicit model, at the expense of
+          -- taking /O(n^-2)/ more time.
+    -> FilePath
+    -> SymbolicObj2
+    -> IO ()
 writeGCodeHacklabLaser = Export.writeGCodeHacklabLaser
 
-writePNG2 :: ℝ -> FilePath -> SymbolicObj2  -> IO ()
+writePNG2
+    :: ℝ  -- ^ Rendering resolution, in millimeters. Smaller values produce
+          -- exports more faithful to the implicit model, at the expense of
+          -- taking /O(n^-2)/ more time.
+    -> FilePath
+    -> SymbolicObj2
+    -> IO ()
 writePNG2 = Export.writePNG
 
-writePNG3 :: ℝ -> FilePath -> SymbolicObj3  -> IO ()
+writePNG3
+    :: ℝ  -- ^ Rendering resolution, in millimeters. Smaller values produce
+          -- exports more faithful to the implicit model, at the expense of
+          -- taking /O(n^-3)/ more time.
+    -> FilePath
+    -> SymbolicObj3
+    -> IO ()
 writePNG3 = Export.writePNG
 

--- a/Graphics/Implicit.hs
+++ b/Graphics/Implicit.hs
@@ -7,19 +7,72 @@
    this haskell library. -}
 
 module Graphics.Implicit (
-  module P,
-  module E,
-  module W,
+  -- * Types
+  W.ℝ,
+  W.ℝ2,
+  W.ℝ3,
+  SymbolicObj2 (),
+  SymbolicObj3 (),
+  W.ExtrudeRMScale(C1, C2, Fn),
+
+  -- * Shared operations
+  P.Object
+    ( P.translate,
+      P.scale,
+      P.complement,
+      P.unionR,
+      P.intersectR,
+      P.differenceR,
+      P.implicit,
+      P.shell
+    ),
+  P.union,
+  P.intersect,
+  P.difference,
+
+  -- * 2D primitive shapes
+  P.rectR,
+  P.circle,
+  P.polygonR,
+
+  -- * 2D operations
+  P.rotate,
+  P.pack2,
+
+  -- * 3D primitive shapes
+  P.rect3R,
+  P.sphere,
+  P.cylinder,
+  P.cylinder2,
+
+  -- * 3D operations
+  P.rotate3,
+  P.rotate3V,
+  P.pack3,
+
+  -- * Extrusions into 3D
+  P.extrudeR,
+  P.extrudeRM,
+  P.extrudeRotateR,
+  P.extrudeOnEdgeOf,
+  P.rotateExtrude,
+
+  -- * OpenScad support
+  E.runOpenscad,
+
+  -- * 2D exporters
   writeSVG,
+  writePNG2,
   writeDXF2,
+  writeSCAD2,
+  writeGCodeHacklabLaser,
+
+  -- * 3D exporters
   writeSTL,
   writeBinSTL,
   writeOBJ,
   writeTHREEJS,
-  writeSCAD2,
   writeSCAD3,
-  writeGCodeHacklabLaser,
-  writePNG2,
   writePNG3
 ) where
 

--- a/Graphics/Implicit.hs
+++ b/Graphics/Implicit.hs
@@ -33,7 +33,7 @@ import Graphics.Implicit.Primitives as P (translate, scale, complement, union, i
 import Graphics.Implicit.ExtOpenScad as E (runOpenscad)
 
 -- typesclasses and types defining the world, or part of the world.
-import Graphics.Implicit.Definitions as W (ℝ, SymbolicObj2, SymbolicObj3, ExtrudeRMScale(C1, C2, Fn))
+import Graphics.Implicit.Definitions as W (ℝ, ℝ2, ℝ3, SymbolicObj2, SymbolicObj3, ExtrudeRMScale(C1, C2, Fn))
 
 -- Functions for writing files based on the result of operations on primitives.
 import qualified Graphics.Implicit.Export as Export (writeSVG, writeDXF2, writeSTL, writeBinSTL, writeOBJ, writeSCAD2, writeSCAD3, writeTHREEJS, writeGCodeHacklabLaser, writePNG)

--- a/Graphics/Implicit/Definitions.hs
+++ b/Graphics/Implicit/Definitions.hs
@@ -121,7 +121,7 @@ allthree f (x,y,z) = (f x, f y, f z)
 
 -- Wrap the functions that convert datatypes.
 
--- | Convert from our Integral to our Rational. 
+-- | Convert from our Integral to our Rational.
 fromℕtoℝ :: ℕ -> ℝ
 fromℕtoℝ = fromIntegral
 {-# INLINABLE fromℕtoℝ #-}
@@ -263,7 +263,7 @@ data SymbolicObj3 =
     -- Primitives
       Rect3R ℝ ℝ3 ℝ3 -- rounding, start, stop.
     | Sphere ℝ -- radius
-    | Cylinder ℝ ℝ ℝ -- 
+    | Cylinder ℝ ℝ ℝ --
     -- (Rounded) CSG
     | Complement3 SymbolicObj3
     | UnionR3 ℝ [SymbolicObj3]

--- a/Graphics/Implicit/Definitions.hs
+++ b/Graphics/Implicit/Definitions.hs
@@ -91,10 +91,18 @@ import Graphics.Implicit.IntegralUtil as N (ℕ, fromℕ, toℕ)
 
 import Control.DeepSeq (NFData, rnf)
 
--- Let's make things a bit nicer. 
--- Following the math notation ℝ, ℝ², ℝ³...
+-- | A type synonym for 'Double'. When used in the context of positions or
+-- sizes, measured in units of millimeters. When used as in the context of
+-- a rotation, measured in radians.
 type ℝ = Double
+
+-- | A pair of two 'Double's. When used as an area or position vector, measured
+-- in millimeters squared.
 type ℝ2 = (ℝ,ℝ)
+
+-- | A triple of 'Double's. When used as a volume or position vector, measured
+-- in millimeters cubed. When used as a rotation, interpreted as Euler angles
+-- measured in radians.
 type ℝ3 = (ℝ,ℝ,ℝ)
 
 -- | A give up point for dividing ℝs, and for the maximum difference between abs(n) and abs(-n).

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -120,7 +120,7 @@ circle ::
 circle   = Circle
 
 rectR ::
-    ℝ 				-- ^ Rounding of corners
+    ℝ               -- ^ Rounding of corners
     -> ℝ2           -- ^ Bottom left corner
     -> ℝ2           -- ^ Top right corner
     -> SymbolicObj2 -- ^ Resulting square (bottom right = (0,0) )
@@ -245,21 +245,21 @@ extrudeR = ExtrudeR
 extrudeRotateR :: ℝ -> ℝ -> SymbolicObj2 -> ℝ -> SymbolicObj3
 extrudeRotateR = ExtrudeRotateR
 
-extrudeRM :: ℝ  			-- ^ rounding radius
-    -> Either ℝ (ℝ -> ℝ)	-- ^ twist
-    -> ExtrudeRMScale		-- ^ scale
-    -> Either ℝ2 (ℝ -> ℝ2)	-- ^ translate
-    -> SymbolicObj2			-- ^ object to extrude
-    -> Either ℝ (ℝ2 -> ℝ)	-- ^ height to extrude to
+extrudeRM :: ℝ              -- ^ rounding radius
+    -> Either ℝ (ℝ -> ℝ)    -- ^ twist
+    -> ExtrudeRMScale       -- ^ scale
+    -> Either ℝ2 (ℝ -> ℝ2)  -- ^ translate
+    -> SymbolicObj2         -- ^ object to extrude
+    -> Either ℝ (ℝ2 -> ℝ)   -- ^ height to extrude to
     -> SymbolicObj3
 extrudeRM = ExtrudeRM
 
 
 rotateExtrude :: ℝ            -- ^ Angle to sweep to
-	-> (Maybe ℝ)             -- ^ Loop or path (rounded corner)
-	-> (Either ℝ2 (ℝ -> ℝ2)) -- ^ translate
-	-> (Either ℝ  (ℝ -> ℝ )) -- ^ rotate
-	-> SymbolicObj2          -- ^ object to extrude
+    -> (Maybe ℝ)              -- ^ Loop or path (rounded corner)
+    -> (Either ℝ2 (ℝ -> ℝ2))  -- ^ translate
+    -> (Either ℝ  (ℝ -> ℝ ))  -- ^ rotate
+    -> SymbolicObj2           -- ^ object to extrude
     -> SymbolicObj3
 rotateExtrude = RotateExtrude
 

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -248,7 +248,12 @@ intersect = intersectR 0
 
 -- 3D operations
 
-extrudeR :: ℝ -> SymbolicObj2 -> ℝ -> SymbolicObj3
+-- | Extrude a 2d object upwards, with rounded corners.
+extrudeR
+    :: ℝ   -- ^ Rounding radius (in mm) of corners
+    -> SymbolicObj2
+    -> ℝ   -- ^ Extrusion height
+    -> SymbolicObj3
 extrudeR = ExtrudeR
 
 -- | This function is not implemented

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -89,6 +89,7 @@ sphere ::
 
 sphere = Sphere
 
+-- | A rectangular prism, with rounded corners.
 rect3R ::
     ℝ                 -- ^ Rounding of corners
     -> ℝ3             -- ^ Bottom.. corner
@@ -97,6 +98,7 @@ rect3R ::
 
 rect3R = Rect3R
 
+-- | A conical frustum --- ie. a cylinder with different radii at either end.
 cylinder2 ::
     ℝ                   -- ^ Radius of the cylinder
     -> ℝ                -- ^ Second radius of the cylinder
@@ -120,16 +122,18 @@ circle ::
 
 circle   = Circle
 
+-- | A rectangle, with rounded corners.
 rectR ::
-    ℝ               -- ^ Rounding of corners
+    ℝ               -- ^ Rounding radius (in mm) of corners
     -> ℝ2           -- ^ Bottom left corner
     -> ℝ2           -- ^ Top right corner
     -> SymbolicObj2 -- ^ Resulting square (bottom right = (0,0) )
 
 rectR = RectR
 
+-- | A 2D polygon, with rounded corners.
 polygonR ::
-    ℝ                -- ^ Rouding of the polygon
+    ℝ                -- ^ Rounding radius (in mm) of the polygon
     -> [ℝ2]          -- ^ Verticies of the polygon
     -> SymbolicObj2  -- ^ Resulting polygon
 
@@ -137,7 +141,11 @@ polygonR = PolygonR
 
 -- $ Shared Operations
 
--- | Operations available on both 2D and 3D objects.
+-- | Operations available on both 2D and 3D objects. The obvious omission of
+-- rotation operations from this class are a technical limitation, and are
+-- instead provided by 'rotate' and 'rotate3'.
+--
+-- Library users shouldn't need to provide new instances of this class.
 class Object obj vec | obj -> vec where
 
     -- | Complement an Object
@@ -147,25 +155,25 @@ class Object obj vec | obj -> vec where
 
     -- | Rounded union
     unionR ::
-        ℝ        -- ^ The radius of rounding
+        ℝ        -- ^ The radius (in mm) of rounding
         -> [obj] -- ^ objects to union
         -> obj   -- ^ Resulting object
 
     -- | Rounded difference
     differenceR ::
-        ℝ        -- ^ The radius of rounding
+        ℝ        -- ^ The radius (in mm) of rounding
         -> [obj] -- ^ Objects to difference
         -> obj   -- ^ Resulting object
 
     -- | Rounded minimum
     intersectR ::
-        ℝ        -- ^ The radius of rounding
+        ℝ        -- ^ The radius (in mm) of rounding
         -> [obj] -- ^ Objects to intersect
         -> obj   -- ^ Resulting object
 
     -- | Translate an object by a vector of appropriate dimension.
     translate ::
-        vec      -- ^ Vector to translate by (Also: a is a vector, blah, blah)
+        vec      -- ^ Vector to translate by
         -> obj   -- ^ Object to translate
         -> obj   -- ^ Resulting object
 
@@ -247,7 +255,7 @@ extrudeR = ExtrudeR
 extrudeRotateR :: ℝ -> ℝ -> SymbolicObj2 -> ℝ -> SymbolicObj3
 extrudeRotateR = ExtrudeRotateR
 
-extrudeRM :: ℝ              -- ^ rounding radius
+extrudeRM :: ℝ              -- ^ rounding radius (in mm)
     -> Either ℝ (ℝ -> ℝ)    -- ^ twist
     -> ExtrudeRMScale       -- ^ scale
     -> Either ℝ2 (ℝ -> ℝ2)  -- ^ translate
@@ -257,7 +265,7 @@ extrudeRM :: ℝ              -- ^ rounding radius
 extrudeRM = ExtrudeRM
 
 
-rotateExtrude :: ℝ            -- ^ Angle to sweep to
+rotateExtrude :: ℝ            -- ^ Angle to sweep to (in rad)
     -> (Maybe ℝ)              -- ^ Loop or path (rounded corner)
     -> (Either ℝ2 (ℝ -> ℝ2))  -- ^ translate
     -> (Either ℝ  (ℝ -> ℝ ))  -- ^ rotate
@@ -268,10 +276,17 @@ rotateExtrude = RotateExtrude
 extrudeOnEdgeOf :: SymbolicObj2 -> SymbolicObj2 -> SymbolicObj3
 extrudeOnEdgeOf = ExtrudeOnEdgeOf
 
+-- | Rotate a 3D object via an Euler angle, measured in radians, along the
+-- world axis.
 rotate3 :: ℝ3 -> SymbolicObj3 -> SymbolicObj3
 rotate3 = Rotate3
 
-rotate3V :: ℝ -> ℝ3 -> SymbolicObj3 -> SymbolicObj3
+-- | Rotate a 3D object along an arbitrary axis.
+rotate3V
+    :: ℝ   -- ^ Angle of rotation
+    -> ℝ3  -- ^ Axis of rotation
+    -> SymbolicObj3
+    -> SymbolicObj3
 rotate3V = Rotate3V
 
 -- FIXME: shouldn't this pack into a 3d area, or have a 3d equivalent?

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -137,6 +137,7 @@ polygonR = PolygonR
 
 -- $ Shared Operations
 
+-- | Operations available on both 2D and 3D objects.
 class Object obj vec | obj -> vec where
 
     -- | Complement an Object

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -295,7 +295,14 @@ rotate3V
 rotate3V = Rotate3V
 
 -- FIXME: shouldn't this pack into a 3d area, or have a 3d equivalent?
-pack3 :: ℝ2 -> ℝ -> [SymbolicObj3] -> Maybe SymbolicObj3
+-- | Attempt to pack multiple 3D objects into a fixed area. The @z@ coordinate
+-- of each object is dropped, and the resulting packed objects will all be on
+-- the same plane.
+pack3
+    :: ℝ2                  -- ^ Area to pack
+    -> ℝ                   -- ^ Separation between objects
+    -> [SymbolicObj3]      -- ^ Objects to pack
+    -> Maybe SymbolicObj3  -- ^ 'Just' if the objects could be packed into the given area
 pack3 (dx, dy) sep objs =
     let
         boxDropZ :: (ℝ3,ℝ3) -> (ℝ2,ℝ2)
@@ -311,7 +318,12 @@ pack3 (dx, dy) sep objs =
 rotate :: ℝ -> SymbolicObj2 -> SymbolicObj2
 rotate = Rotate2
 
-pack2 :: ℝ2 -> ℝ -> [SymbolicObj2] -> Maybe SymbolicObj2
+-- | Attempt to pack multiple 2D objects into a fixed area.
+pack2
+    :: ℝ2                  -- ^ Area to pack
+    -> ℝ                   -- ^ Separation between objects
+    -> [SymbolicObj2]      -- ^ Objects to pack
+    -> Maybe SymbolicObj2  -- ^ 'Just' if the objects could be packed into the given area
 pack2 (dx, dy) sep objs =
     let
         withBoxes :: [(Box2, SymbolicObj2)]

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -33,7 +33,8 @@ module Graphics.Implicit.Primitives (
                                      pack3,
                                      rotate,
                                      pack2,
-                                     implicit
+                                     implicit,
+                                     Object
                                     ) where
 
 import Prelude(Maybe(Just, Nothing), Either, fmap, ($))

--- a/implicit.cabal
+++ b/implicit.cabal
@@ -95,7 +95,7 @@ Library
                     Graphics.Implicit.Export.PolylineFormats
                     Graphics.Implicit.Export.DiscreteAproxable
                     -- These are exposed for docgen.
-                    Graphics.Implicit.ExtOpenScad.Primitives            
+                    Graphics.Implicit.ExtOpenScad.Primitives
 
     Other-modules:
                   Graphics.Implicit.FastIntUtil


### PR DESCRIPTION
This PR documents most of the top-level functions, insofar as I could figure out what they do. The argument descriptions were deduced from their names in `Graphics.Implicit.ObjectUtil.GetImplicit3`, but could use a second pair of eyes.

In addition, this PR fixes up some of the weird whitespace across the codebase (some trailing spaces, and a few intermingling tabs).

**Potentially breaking change:** I've stopped exporting `extrudeRotateR`, since as @raptortech-js pointed out, it's implemented as `error` and as such has no business existing.

**Additionally:** I've now exported the `Object` class, giving haddock users some indication of what types on which they can use `translate` et al. Also, `R2' and `R3` are now exported.