### PR TITLE
Change the type of differenceR to include a mandatory base shape

### DIFF
--- a/Graphics/Implicit/Definitions.hs
+++ b/Graphics/Implicit/Definitions.hs
@@ -253,7 +253,7 @@ data SymbolicObj2 =
     -- (Rounded) CSG
     | Complement2 SymbolicObj2
     | UnionR2 ℝ [SymbolicObj2]
-    | DifferenceR2 ℝ [SymbolicObj2]
+    | DifferenceR2 ℝ SymbolicObj2 [SymbolicObj2]
     | IntersectR2 ℝ [SymbolicObj2]
     -- Simple transforms
     | Translate2 ℝ2 SymbolicObj2
@@ -275,7 +275,7 @@ data SymbolicObj3 =
     -- (Rounded) CSG
     | Complement3 SymbolicObj3
     | UnionR3 ℝ [SymbolicObj3]
-    | DifferenceR3 ℝ [SymbolicObj3]
+    | DifferenceR3 ℝ SymbolicObj3 [SymbolicObj3]
     | IntersectR3 ℝ [SymbolicObj3]
     -- Simple transforms
     | Translate3 ℝ3 SymbolicObj3

--- a/Graphics/Implicit/Export/SymbolicFormats.hs
+++ b/Graphics/Implicit/Export/SymbolicFormats.hs
@@ -70,7 +70,7 @@ buildS3 (UnionR3 r objs) | r == 0 = call "union" [] $ buildS3 <$> objs
 
 buildS3 (IntersectR3 r objs) | r == 0 = call "intersection" [] $ buildS3 <$> objs
 
-buildS3 (DifferenceR3 r objs) | r == 0 = call "difference" [] $ buildS3 <$> objs
+buildS3 (DifferenceR3 r obj objs) | r == 0 = call "difference" [] $ buildS3 <$> obj : objs
 
 buildS3 (Translate3 (x,y,z) obj) = call "translate" [bf x, bf y, bf z] [buildS3 obj]
 
@@ -112,7 +112,7 @@ buildS3 (ExtrudeRM r twist scale (Left translate) obj (Left height)) | r == 0 &&
 buildS3 Rect3R{} = error "cannot provide roundness when exporting openscad; unsupported in target format."
 buildS3(UnionR3 _ _) = error "cannot provide roundness when exporting openscad; unsupported in target format."
 buildS3(IntersectR3 _ _) = error "cannot provide roundness when exporting openscad; unsupported in target format."
-buildS3(DifferenceR3 _ _) = error "cannot provide roundness when exporting openscad; unsupported in target format."
+buildS3(DifferenceR3 _ _ _) = error "cannot provide roundness when exporting openscad; unsupported in target format."
 buildS3(Outset3 _ _) = error "cannot provide roundness when exporting openscad; unsupported in target format."
 buildS3(Shell3 _ _) = error "cannot provide roundness when exporting openscad; unsupported in target format."
 buildS3 ExtrudeR{} = error "cannot provide roundness when exporting openscad; unsupported in target format."
@@ -139,7 +139,7 @@ buildS2 (Complement2 obj) = call "complement" [] [buildS2 obj]
 
 buildS2 (UnionR2 r objs) | r == 0 = call "union" [] $ buildS2 <$> objs
 
-buildS2 (DifferenceR2 r objs) | r == 0 = call "difference" [] $ buildS2 <$> objs
+buildS2 (DifferenceR2 r obj objs) | r == 0 = call "difference" [] $ buildS2 <$> obj : objs
 
 buildS2 (IntersectR2 r objs) | r == 0 = call "intersection" [] $ buildS2 <$> objs
 
@@ -157,7 +157,7 @@ buildS2 (Shell2 r obj) | r == 0 =  call "shell" [] [buildS2 obj]
 buildS2 RectR{} = error "cannot provide roundness when exporting openscad; unsupported in target format."
 buildS2 (PolygonR _ _) = error "cannot provide roundness when exporting openscad; unsupported in target format."
 buildS2 (UnionR2 _ _) = error "cannot provide roundness when exporting openscad; unsupported in target format."
-buildS2 (DifferenceR2 _ _) = error "cannot provide roundness when exporting openscad; unsupported in target format."
+buildS2 (DifferenceR2 _ _ _) = error "cannot provide roundness when exporting openscad; unsupported in target format."
 buildS2 (IntersectR2 _ _) = error "cannot provide roundness when exporting openscad; unsupported in target format."
 buildS2 (Outset2 _ _) = error "cannot provide roundness when exporting openscad; unsupported in target format."
 buildS2 (Shell2 _ _) = error "cannot provide roundness when exporting openscad; unsupported in target format."

--- a/Graphics/Implicit/ExtOpenScad/Primitives.hs
+++ b/Graphics/Implicit/ExtOpenScad/Primitives.hs
@@ -19,7 +19,7 @@ import Prelude((.), Either(Left, Right), Bool(True, False), Maybe(Just, Nothing)
 
 import Graphics.Implicit.Definitions (ℝ, ℝ2, ℝ3, ℕ, SymbolicObj2, SymbolicObj3, ExtrudeRMScale(C1), fromℕtoℝ, isScaleID)
 
-import Graphics.Implicit.ExtOpenScad.Definitions (OVal (OObj2, OObj3, ONModule), ArgParser, Symbol(Symbol), StateC, SourcePosition)
+import Graphics.Implicit.ExtOpenScad.Definitions (OVal (OObj2, OObj3, ONModule), ArgParser(APFail), Symbol(Symbol), StateC, SourcePosition)
 
 import Graphics.Implicit.ExtOpenScad.Util.ArgParser (doc, defaultTo, example, test, eulerCharacteristic)
 
@@ -32,7 +32,7 @@ import Graphics.Implicit.ExtOpenScad.Util.StateC (errorC)
 -- Note the use of a qualified import, so we don't have the functions in this file conflict with what we're importing.
 import qualified Graphics.Implicit.Primitives as Prim (sphere, rect3R, rectR, translate, circle, polygonR, extrudeR, cylinder2, union, unionR, intersect, intersectR, difference, differenceR, rotate, rotate3V, rotate3, scale, extrudeRM, rotateExtrude, shell, pack3, pack2)
 
-import Control.Monad (mplus)
+import Control.Monad (when, mplus)
 
 import Data.AffineSpace (distanceSq)
 
@@ -346,6 +346,7 @@ intersect = moduleWithSuite "intersection" $ \_ children -> do
 
 difference :: (Symbol, SourcePosition -> [OVal] -> ArgParser (StateC [OVal]))
 difference = moduleWithSuite "difference" $ \_ children -> do
+    when (null children) $ APFail "Call to 'difference' requires at least one child"
     r :: ℝ <- argument "r"
         `defaultTo` 0
         `doc` "Radius of rounding for the difference interface"
@@ -358,6 +359,7 @@ difference = moduleWithSuite "difference" $ \_ children -> do
 
     unsafeUncons :: [a] -> (a, [a])
     unsafeUncons (a : as) = (a, as)
+    -- NOTE: This error is guarded against during the @null children@ check in the function body.
     unsafeUncons _ = error "difference requires at least one element; zero given"
 
 translate :: (Symbol, SourcePosition -> [OVal] -> ArgParser (StateC [OVal]))

--- a/Graphics/Implicit/ExtOpenScad/Primitives.hs
+++ b/Graphics/Implicit/ExtOpenScad/Primitives.hs
@@ -15,7 +15,7 @@
 -- Export one set containing all of the primitive modules.
 module Graphics.Implicit.ExtOpenScad.Primitives (primitiveModules) where
 
-import Prelude(Either(Left, Right), Bool(True, False), Maybe(Just, Nothing), ($), pure, either, id, (-), (==), (&&), (<), (*), cos, sin, pi, (/), (>), const, uncurry, fromInteger, round, (/=), (||), not, null, fmap, (<>), otherwise)
+import Prelude((.), Either(Left, Right), Bool(True, False), Maybe(Just, Nothing), ($), pure, either, id, (-), (==), (&&), (<), (*), cos, sin, pi, (/), (>), const, uncurry, fromInteger, round, (/=), (||), not, null, fmap, (<>), otherwise, error)
 
 import Graphics.Implicit.Definitions (ℝ, ℝ2, ℝ3, ℕ, SymbolicObj2, SymbolicObj3, ExtrudeRMScale(C1), fromℕtoℝ, isScaleID)
 
@@ -350,8 +350,15 @@ difference = moduleWithSuite "difference" $ \_ children -> do
         `defaultTo` 0
         `doc` "Radius of rounding for the difference interface"
     pure $ pure $ if r > 0
-        then objReduce (Prim.differenceR r) (Prim.differenceR r) children
-        else objReduce  Prim.difference      Prim.difference     children
+        then objReduce (unsafeUncurry (Prim.differenceR r)) (unsafeUncurry (Prim.differenceR r)) children
+        else objReduce (unsafeUncurry  Prim.difference)     (unsafeUncurry  Prim.difference)     children
+  where
+    unsafeUncurry :: (a -> [a] -> c) -> [a] -> c
+    unsafeUncurry f = uncurry f . unsafeUncons
+
+    unsafeUncons :: [a] -> (a, [a])
+    unsafeUncons (a : as) = (a, as)
+    unsafeUncons _ = error "difference requires at least one element; zero given"
 
 translate :: (Symbol, SourcePosition -> [OVal] -> ArgParser (StateC [OVal]))
 translate = moduleWithSuite "translate" $ \_ children -> do

--- a/Graphics/Implicit/ObjectUtil/GetBox2.hs
+++ b/Graphics/Implicit/ObjectUtil/GetBox2.hs
@@ -4,7 +4,7 @@
 
 module Graphics.Implicit.ObjectUtil.GetBox2 (getBox2, getBox2R) where
 
-import Prelude(Bool, Fractional, Eq, (==), (||), unzip, minimum, maximum, ($), filter, not, (.), (/), fmap, (-), (+), (*), cos, sin, sqrt, min, max, head, (<), (<>), pi, atan2, (==), (>), show, (&&), otherwise, error)
+import Prelude(Bool, Fractional, Eq, (==), (||), unzip, minimum, maximum, ($), filter, not, (.), (/), fmap, (-), (+), (*), cos, sin, sqrt, min, max, (<), (<>), pi, atan2, (==), (>), show, (&&), otherwise, error)
 
 import Graphics.Implicit.Definitions (ℝ, ℝ2, Box2, (⋯*),
                                       SymbolicObj2(Shell2, Outset2, Circle, Translate2, Rotate2, UnionR2, Scale2, RectR,
@@ -53,7 +53,7 @@ intersectBoxes (x:xs) = if nmaxx > nminx && nmaxy > nminy
                         then ((nminx, nminy), (nmaxx, nmaxy))
                         else emptyBox
   where
-    ((nminx, nminy), (nmaxx, nmaxy)) = ((max xmin1 xmin2, max ymin1 ymin2), (min xmax1 xmax2, min ymax1 ymax2)) 
+    ((nminx, nminy), (nmaxx, nmaxy)) = ((max xmin1 xmin2, max ymin1 ymin2), (min xmax1 xmax2, min ymax1 ymax2))
     ((xmin1, ymin1), (xmax1, ymax1)) = x
     ((xmin2, ymin2), (xmax2, ymax2)) = intersectBoxes xs
 
@@ -76,7 +76,7 @@ getBox2 (Complement2 _) =
           infty = 1/0
 getBox2 (UnionR2 r symbObjs) =
   outsetBox r $ unionBoxes (fmap getBox2 symbObjs)
-getBox2 (DifferenceR2 _ symbObjs) = getBox2 $ head symbObjs
+getBox2 (DifferenceR2 _ symbObj _) = getBox2 symbObj
 getBox2 (IntersectR2 r symbObjs) =
   outsetBox r $ intersectBoxes $ filter (not.isEmpty) $ fmap getBox2 symbObjs
 -- Simple transforms
@@ -129,7 +129,7 @@ getBox2R (UnionR2 r symObjs) deg =
     boxes = [ getBox2R obj deg| obj <- symObjs ]
   in
     outsetBox r $ unionBoxes boxes
-getBox2R (DifferenceR2 _ symObjs) deg = getBox2R (head symObjs) deg
+getBox2R (DifferenceR2 _ symObj _) deg = getBox2R symObj deg
 getBox2R (IntersectR2 r symObjs) deg =
   let
     boxes = [ getBox2R obj deg| obj <- symObjs ]
@@ -263,7 +263,7 @@ pointRBox (xStart, yStart) travel =
     twoAxis :: Axis -> Axis -> Direction -> Box2
     twoAxis start stop dir
       | (start == PosX && stop == NegX) ||
-        (start == PosY && stop == NegY) || 
+        (start == PosY && stop == NegY) ||
         (start == NegX && stop == PosX) ||
         (start == NegY && stop == PosY)  = crossOne start dir
     twoAxis start stop dir
@@ -310,7 +310,7 @@ pointRBox (xStart, yStart) travel =
     mixWith :: [ℝ2] -> Box2
     mixWith points = ((minimum xPoints, minimum yPoints), (maximum xPoints, maximum yPoints))
                      where
-                       (xPoints, yPoints) = unzip $ points <> [(xStart, yStart), (xStop, yStop)] 
+                       (xPoints, yPoints) = unzip $ points <> [(xStart, yStart), (xStop, yStop)]
     invertRotation :: Direction -> Direction
     invertRotation Clockwise = CounterClockwise
     invertRotation CounterClockwise = Clockwise

--- a/Graphics/Implicit/ObjectUtil/GetBox3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetBox3.hs
@@ -5,7 +5,7 @@
 
 module Graphics.Implicit.ObjectUtil.GetBox3 (getBox3) where
 
-import Prelude(Eq, Bool(False), Fractional, Either (Left, Right), (==), (||), max, (/), (-), (+), fmap, unzip, ($), (<$>), filter, not, (.), unzip3, minimum, maximum, min, (>), (&&), head, (*), (<), abs, either, error, const, otherwise, take, fst, snd)
+import Prelude(Eq, Bool(False), Fractional, Either (Left, Right), (==), (||), max, (/), (-), (+), fmap, unzip, ($), (<$>), filter, not, (.), unzip3, minimum, maximum, min, (>), (&&), (*), (<), abs, either, error, const, otherwise, take, fst, snd)
 
 import Graphics.Implicit.Definitions (ℝ, Fastℕ, Box3, SymbolicObj3 (Rect3R, Sphere, Cylinder, Complement3, UnionR3, IntersectR3, DifferenceR3, Translate3, Scale3, Rotate3, Rotate3V, Shell3, Outset3, EmbedBoxedObj3, ExtrudeR, ExtrudeOnEdgeOf, ExtrudeRM, RotateExtrude, ExtrudeRotateR), SymbolicObj2 (Rotate2, RectR), ExtrudeRMScale(C1, C2), (⋯*), fromFastℕtoℝ, fromFastℕ, toScaleFn)
 
@@ -54,7 +54,7 @@ getBox3 (UnionR3 r symbObjs) = outsetBox r ((left,bot,inward), (right,top,out))
         right = maximum rights
         top = maximum tops
         out = maximum outs
-getBox3 (DifferenceR3 _ symbObjs)  = getBox3 $ head symbObjs
+getBox3 (DifferenceR3 _ symbObj _)  = getBox3 symbObj
 getBox3 (IntersectR3 _ symbObjs) =
     let
         boxes = fmap getBox3 symbObjs
@@ -149,7 +149,7 @@ getBox3 (ExtrudeRM _ twist scale translate symbObj height) =
             smin s v = min v (s * v)
             smax s v = max v (s * v)
             -- FIXME: assumes minimums are negative, and maximums are positive.
-            scaleEach ((d1, d2),(d3, d4)) = (scalex' * d1, scaley' * d2, scalex' * d3, scaley' * d4) 
+            scaleEach ((d1, d2),(d3, d4)) = (scalex' * d1, scaley' * d2, scalex' * d3, scaley' * d4)
           in case twist of
             Left twval -> if twval == 0
                           then (smin scalex' x1, smin scaley' y1, smax scalex' x2, smax scaley' y2)

--- a/Graphics/Implicit/ObjectUtil/GetImplicit2.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit2.hs
@@ -4,7 +4,7 @@
 
 module Graphics.Implicit.ObjectUtil.GetImplicit2 (getImplicit2) where
 
-import Prelude(abs, (-), (/), sqrt, (*), (+), mod, length, fmap, (<=), (&&), (>=), (||), odd, ($), (>), filter, (<), minimum, max, cos, sin, head, tail, (.))
+import Prelude(abs, (-), (/), sqrt, (*), (+), mod, length, fmap, (<=), (&&), (>=), (||), odd, ($), (>), filter, (<), minimum, max, cos, sin, tail, (.))
 
 import Graphics.Implicit.Definitions (ℝ, ℕ, ℝ2, (⋯/), Obj2, SymbolicObj2(RectR, Circle, PolygonR, Complement2, UnionR2, DifferenceR2, IntersectR2, Translate2, Scale2, Rotate2, Shell2, Outset2, EmbedBoxedObj2))
 
@@ -52,10 +52,10 @@ getImplicit2 (UnionR2 r symbObjs) =
         objs = fmap getImplicit2 symbObjs
     in
         rminimum r $ fmap ($p) objs
-getImplicit2 (DifferenceR2 r symbObjs) =
+getImplicit2 (DifferenceR2 r symbObj symbObjs) =
     let
         objs = fmap getImplicit2 symbObjs
-        obj = head objs
+        obj = getImplicit2 symbObj
         complement :: Obj2 -> ℝ2 -> ℝ
         complement obj' p = - obj' p
     in

--- a/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
@@ -5,7 +5,7 @@
 
 module Graphics.Implicit.ObjectUtil.GetImplicit3 (getImplicit3) where
 
-import Prelude (Either(Left, Right), abs, (-), (/), (*), sqrt, (+), atan2, max, cos, fmap, minimum, ($), (**), sin, pi, (.), Bool(True, False), ceiling, floor, pure, error, head, tail, (>), (&&), (<), (==), otherwise, (<$>))
+import Prelude (Either(Left, Right), abs, (-), (/), (*), sqrt, (+), atan2, max, cos, fmap, minimum, ($), (**), sin, pi, (.), Bool(True, False), ceiling, floor, pure, error, (>), (&&), (<), (==), otherwise, (<$>))
 
 import Graphics.Implicit.Definitions (ℝ, ℕ, ℝ2, ℝ3, (⋯/), Obj3,
                                       SymbolicObj3(Shell3, UnionR3, IntersectR3, DifferenceR3, Translate3, Scale3, Rotate3,
@@ -54,10 +54,10 @@ getImplicit3 (UnionR3 r symbObjs) =
 getImplicit3 (IntersectR3 r symbObjs) =
   \p -> rmaximum r $ fmap ($p) $ getImplicit3 <$> symbObjs
 
-getImplicit3 (DifferenceR3 r symbObjs) =
+getImplicit3 (DifferenceR3 r symbObj symbObjs) =
     let
-        tailObjs = getImplicit3 <$> tail symbObjs
-        headObj = getImplicit3 $ head symbObjs
+        tailObjs = getImplicit3 <$> symbObjs
+        headObj = getImplicit3 symbObj
         complement :: Obj3 -> ℝ3 -> ℝ
         complement obj' p = - obj' p
     in

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -162,7 +162,8 @@ class Object obj vec | obj -> vec where
     -- | Rounded difference
     differenceR ::
         ℝ        -- ^ The radius (in mm) of rounding
-        -> [obj] -- ^ Objects to difference
+        -> obj   -- ^ Base object
+        -> [obj] -- ^ Objects to subtract from the base
         -> obj   -- ^ Resulting object
 
     -- | Rounded minimum
@@ -240,7 +241,7 @@ instance Object SymbolicObj3 ℝ3 where
 union :: Object obj vec => [obj] -> obj
 union = unionR 0
 
-difference :: Object obj vec => [obj] -> obj
+difference :: Object obj vec => obj -> [obj] -> obj
 difference = differenceR 0
 
 intersect :: Object obj vec => [obj] -> obj


### PR DESCRIPTION
tl;dr: changes the type of `differenceR` from `Object obj vec => R -> [obj] -> obj` to `Object obj vec => R -> obj -> [obj] -> obj`.

The first element of the list argument to `differenceR` is special, and
acts as the shape from which the others are subtracted. The previous
behavior of exporting `differenceR r []` (or even `differenceR [x]`) was
to crash due to `head` and `tail` being partial functions.

From this analysis, it's clear that the "shape to remove from" is
a *mandatory* argument to `differenceR`, and as such should be
explicitly moved out of the list args.

Fixes #293

**Note:** I don't understand how the scad parser should deal with this, so I just hammered this in there. Please take a look (right now I'm just calling `error`.)