### PR TITLE
Unioning semigroup and monoid instances for symbolic objects

### DIFF
--- a/Graphics/Implicit/Definitions.hs
+++ b/Graphics/Implicit/Definitions.hs
@@ -314,6 +314,14 @@ data SymbolicObj3 =
     | ExtrudeOnEdgeOf SymbolicObj2 SymbolicObj2
     deriving Show
 
+-- | Semigroup under 'Graphic.Implicit.Primitives.union'.
+instance Semigroup SymbolicObj3 where
+  a <> b = UnionR3 0 [a, b]
+
+-- | Monoid under 'Graphic.Implicit.Primitives.union'.
+instance Monoid SymbolicObj3 where
+  mempty = Rect3R 0 (0, 0, 0) (0, 0, 0)
+
 data ExtrudeRMScale =
       C1 ℝ                  -- constant ℝ
     | C2 ℝ2                 -- constant ℝ2

--- a/Graphics/Implicit/Definitions.hs
+++ b/Graphics/Implicit/Definitions.hs
@@ -79,7 +79,7 @@ module Graphics.Implicit.Definitions (
     )
 where
 
-import Prelude (Show, Double, Either(Left, Right), Bool(True, False), show, (*), (/), fromIntegral, Float, realToFrac)
+import Prelude (Semigroup((<>)), Monoid (mempty), Show, Double, Either(Left, Right), Bool(True, False), show, (*), (/), fromIntegral, Float, realToFrac)
 
 import Data.Maybe (Maybe)
 
@@ -265,6 +265,14 @@ data SymbolicObj2 =
     -- Misc
     | EmbedBoxedObj2 BoxedObj2
     deriving Show
+
+-- | Semigroup under 'Graphic.Implicit.Primitives.union'.
+instance Semigroup SymbolicObj2 where
+  a <> b = UnionR2 0 [a, b]
+
+-- | Monoid under 'Graphic.Implicit.Primitives.union'.
+instance Monoid SymbolicObj2 where
+  mempty = RectR 0 (0, 0) (0, 0)
 
 -- | A symbolic 3D format!
 data SymbolicObj3 =

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -229,7 +229,8 @@ instance Object SymbolicObj3 ℝ3 where
     translate   = Translate3
     scale       = Scale3
     complement  = Complement3
-    unionR      = UnionR3
+    unionR _ [] = mempty
+    unionR r ss = UnionR3 r ss
     intersectR  = IntersectR3
     differenceR = DifferenceR3
     outset      = Outset3

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -37,7 +37,7 @@ module Graphics.Implicit.Primitives (
                                      Object
                                     ) where
 
-import Prelude(Maybe(Just, Nothing), Either, fmap, ($))
+import Prelude(mempty, Maybe(Just, Nothing), Either, fmap, ($))
 
 import Graphics.Implicit.Definitions (ℝ, ℝ2, ℝ3, Box2,
                                       SymbolicObj2(
@@ -215,7 +215,8 @@ instance Object SymbolicObj2 ℝ2 where
     translate   = Translate2
     scale       = Scale2
     complement  = Complement2
-    unionR      = UnionR2
+    unionR _ [] = mempty
+    unionR r ss = UnionR2 r ss
     intersectR  = IntersectR2
     differenceR = DifferenceR2
     outset      = Outset2


### PR DESCRIPTION
A common pattern in Haskell is to use the `Semigroup` class for combining elements (in some associative and meaningful way for the type), and using `Monoid` to produce an empty value of that type --- subject to the constraint that the empty value should be an identity with respect to the semigroup operation.

This PR gives `Semigroup` instances for symbolic objects, implemented as `union`, and an empty element that fills no volume (implemented as `rect zero zero`, but any zero-volume object would work.) 

Why arbitrarily choose `union` as the semigroup operation? It seems more useful than `intersect`, and `difference` isn't associative. Furthermore, we're in good company, since `diagrams` makes the same choice for their semigroup.

This PR also sidesteps a bug where `union []` would corrupt the raytraced output. I have no idea what causes that behavior (at first glance it's use of the partial function `minimum` in `Box3`, but fixing that doesn't fix the issue.) Instead this PR intercepts calls of the form `union []` and rewrites them as `mempty`.