### PR TITLE
ChangeLog and Readme TODO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+
+# Version [next](https://github.com/colah/ImplicitCAD/compare/v0.3.0.0...master) (202Y-MM-DD)
+
+* Changelog started. Previous release was `0.3.0.1`.
+
+* Haskell interface changes
+  * Added support for XY-scaling on `linear_extrude` [#269](https://github.com/colah/ImplicitCAD/pull/269)
+    * `ExtrudeRM` scale type changes from `(Either ℝ (ℝ -> ℝ))` to `ExtrudeRMScale`
+  * Replaced the Rect primitives with SquareR and CubeR [#296](https://github.com/colah/ImplicitCAD/pull/296)
+    * `squareR` and `cubeR` are now available
+  * Added support for mirroring objects around axis using `mirror` function [#300](https://github.com/colah/ImplicitCAD/pull/300)
+  * `differenceR` changes type to require mandatory shape to substract from [#294](https://github.com/colah/ImplicitCAD/pull/294)
+    * from `Object obj vec => R -> [obj] -> obj`
+    * to `Object obj vec => R -> obj -> [obj] -> obj`
+  * Both `SymbolicObj2` and `SymbolicObj3` now have `Semigroup` and `Monoid` instances, where `<>` acts as `union` [#301](https://github.com/colah/ImplicitCAD/pull/301)
+
+* ExtOpenSCAD interface changes
+  * `scale` function with single parameter now behaves similar to OpenSCAD one [#258](https://github.com/colah/ImplicitCAD/pull/258)
+    * scales 2D object in both dimensions
+  * `rotateExtrude` angle `a` parameter renamed to `angle` to match OpenSCAD [#259](https://github.com/colah/ImplicitCAD/pull/259)
+  * Added `mirror` support [#300](https://github.com/colah/ImplicitCAD/pull/300)
+
+* Other changes
+  * Fixed the ExtOpenSCAD lexer bug where newlines were part of identifiers [#256](https://github.com/colah/ImplicitCAD/pull/256)
+  * `implicitsnap` not built by default anymore [#272](https://github.com/colah/ImplicitCAD/pull/272)
+    * Can be enabled again with `cabal configure --flag=implicitsnap`
+  * Fixed vertex coordinates of OBJ output [#281](https://github.com/colah/ImplicitCAD/pull/281)
+    * `discreteAprox` of `NormedTriangleMesh` now runs in parallel [#282](https://github.com/colah/ImplicitCAD/pull/282)
+  * Binaries now built with default `-rtsopts "-with-rtsopts -N -qg -t"` to allow automatic parallelization
+  * Added haddocks for Haskell eDSL [#284](https://github.com/colah/ImplicitCAD/pull/284) & [#287](https://github.com/colah/ImplicitCAD/pull/287)
+  * Added golden test machinery [#311](https://github.com/colah/ImplicitCAD/pull/311)
+  * Added quickcheck test machinery for implicit functions [#316](https://github.com/colah/ImplicitCAD/pull/316)
+  * Rotate now internally uses quaternions [#314](https://github.com/colah/ImplicitCAD/pull/314)

--- a/README.md
+++ b/README.md
@@ -304,7 +304,9 @@ What works (January 26th, 2020 -- regressions are possible if not probable):
 What still needs to be done:
 
  - ~gcode generation for 3D printers, gcode generator config.~ -- now a seperate program, [HSlice](https://github.com/julialongtin/hslice/)!
- - Multi-material support.
+ - Multi-material / color support.
+ - Hull support.
+ - Minkowski sum support.
 
 And a wishlist of things to be done as we go:
  - More optimisation.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ImplicitCAD: Math Inspired CAD
 ==============================
 
-[![Hackage version](https://img.shields.io/hackage/v/implicit.svg?style=flat)](https://hackage.haskell.org/package/implicit)  [![Build Status](https://travis-ci.org/colah/ImplicitCAD.png?branch=master)](https://travis-ci.org/colah/ImplicitCAD)
+[![Hackage version](https://img.shields.io/hackage/v/implicit.svg?style=flat)](https://hackage.haskell.org/package/implicit) [![IRC](https://img.shields.io/badge/irc.freenode.net-%23ImplicitCAD-blue.svg)](https://freenode.net/)
 
 Introduction
 ------------


### PR DESCRIPTION
Rendered: https://github.com/sorki/ImplicitCAD/blob/readme_changelog/CHANGELOG.md

`v0.3.0.0` in diff link needs to be unified with  `Previous release was ...` but the `v0.3.0.1` tag is missing.