### PR TITLE
Use Quaternions for Rotate3

### DIFF
--- a/Graphics/Implicit/Definitions.hs
+++ b/Graphics/Implicit/Definitions.hs
@@ -62,7 +62,6 @@ module Graphics.Implicit.Definitions (
         Translate3,
         Scale3,
         Rotate3,
-        Rotate3V,
         Mirror3,
         Shell3,
         Outset3,
@@ -294,7 +293,6 @@ data SymbolicObj3 =
     | Translate3 ℝ3 SymbolicObj3
     | Scale3 ℝ3 SymbolicObj3
     | Rotate3 (Quaternion Double) SymbolicObj3
-    | Rotate3V ℝ ℝ3 SymbolicObj3
     | Mirror3 ℝ3 SymbolicObj3  -- mirror across the plane whose normal is the R3
     -- Boundary mods
     | Outset3 ℝ SymbolicObj3

--- a/Graphics/Implicit/Definitions.hs
+++ b/Graphics/Implicit/Definitions.hs
@@ -292,7 +292,7 @@ data SymbolicObj3 =
     -- Simple transforms
     | Translate3 ℝ3 SymbolicObj3
     | Scale3 ℝ3 SymbolicObj3
-    | Rotate3 (Quaternion Double) SymbolicObj3
+    | Rotate3 (Quaternion ℝ) SymbolicObj3
     | Mirror3 ℝ3 SymbolicObj3  -- mirror across the plane whose normal is the R3
     -- Boundary mods
     | Outset3 ℝ SymbolicObj3

--- a/Graphics/Implicit/Definitions.hs
+++ b/Graphics/Implicit/Definitions.hs
@@ -93,6 +93,8 @@ import Graphics.Implicit.IntegralUtil as N (ℕ, fromℕ, toℕ)
 
 import Control.DeepSeq (NFData, rnf)
 
+import Linear.Quaternion (Quaternion)
+
 -- | A type synonym for 'Double'. When used in the context of positions or
 -- sizes, measured in units of millimeters. When used as in the context of
 -- a rotation, measured in radians.
@@ -291,7 +293,7 @@ data SymbolicObj3 =
     -- Simple transforms
     | Translate3 ℝ3 SymbolicObj3
     | Scale3 ℝ3 SymbolicObj3
-    | Rotate3 ℝ3 SymbolicObj3
+    | Rotate3 (Quaternion Double) SymbolicObj3
     | Rotate3V ℝ ℝ3 SymbolicObj3
     | Mirror3 ℝ3 SymbolicObj3  -- mirror across the plane whose normal is the R3
     -- Boundary mods

--- a/Graphics/Implicit/Export/SymbolicFormats.hs
+++ b/Graphics/Implicit/Export/SymbolicFormats.hs
@@ -10,7 +10,7 @@ module Graphics.Implicit.Export.SymbolicFormats (scad2, scad3) where
 
 import Prelude(fmap, Either(Left, Right), ($), (*), ($!), (-), (/), pi, error, (+), (==), take, floor, (&&), const, pure, (<>), sequenceA, (<$>))
 
-import Graphics.Implicit.Definitions(ℝ2, ℝ3, ℝ, SymbolicObj2(SquareR, Circle, PolygonR, Complement2, UnionR2, DifferenceR2, IntersectR2, Translate2, Scale2, Rotate2, Mirror2, Outset2, Shell2, EmbedBoxedObj2), SymbolicObj3(CubeR, Sphere, Cylinder, Complement3, UnionR3, IntersectR3, DifferenceR3, Translate3, Scale3, Rotate3, Rotate3V, Mirror3, Outset3, Shell3, ExtrudeR, ExtrudeRotateR, ExtrudeRM, EmbedBoxedObj3, RotateExtrude, ExtrudeOnEdgeOf), isScaleID)
+import Graphics.Implicit.Definitions(ℝ2, ℝ3, ℝ, SymbolicObj2(SquareR, Circle, PolygonR, Complement2, UnionR2, DifferenceR2, IntersectR2, Translate2, Scale2, Rotate2, Mirror2, Outset2, Shell2, EmbedBoxedObj2), SymbolicObj3(CubeR, Sphere, Cylinder, Complement3, UnionR3, IntersectR3, DifferenceR3, Translate3, Scale3, Rotate3, Mirror3, Outset3, Shell3, ExtrudeR, ExtrudeRotateR, ExtrudeRM, EmbedBoxedObj3, RotateExtrude, ExtrudeOnEdgeOf), isScaleID)
 import Graphics.Implicit.Export.TextBuilderUtils(Text, Builder, toLazyText, fromLazyText, bf)
 
 import Control.Monad.Reader (Reader, runReader, ask)
@@ -84,8 +84,6 @@ buildS3 (Scale3 (x,y,z) obj) = call "scale" [bf x, bf y, bf z] [buildS3 obj]
 buildS3 (Rotate3 q obj) =
   let (x,y,z) = quaternionToEuler q
    in call "rotate" [bf (rad2deg x), bf (rad2deg y), bf (rad2deg z)] [buildS3 obj]
-
-buildS3 (Rotate3V a v obj) = callNaked "rotate" [ "a=" <> bf (rad2deg a), "v=" <> bvect3 v ] [buildS3 obj]
 
 buildS3 (Mirror3 v obj) = callNaked "mirror" [ "v=" <> bvect3 v ] [buildS3 obj]
 

--- a/Graphics/Implicit/Export/SymbolicFormats.hs
+++ b/Graphics/Implicit/Export/SymbolicFormats.hs
@@ -18,6 +18,7 @@ import Control.Monad.Reader (Reader, runReader, ask)
 import Data.List (intersperse)
 import Data.Function (fix)
 import Data.Foldable(fold, foldMap)
+import Graphics.Implicit.MathUtil (quaternionToEuler)
 
 default (ℝ)
 
@@ -80,7 +81,9 @@ buildS3 (Translate3 (x,y,z) obj) = call "translate" [bf x, bf y, bf z] [buildS3 
 
 buildS3 (Scale3 (x,y,z) obj) = call "scale" [bf x, bf y, bf z] [buildS3 obj]
 
-buildS3 (Rotate3 (x,y,z) obj) = call "rotate" [bf (rad2deg x), bf (rad2deg y), bf (rad2deg z)] [buildS3 obj]
+buildS3 (Rotate3 q obj) =
+  let (x,y,z) = quaternionToEuler q
+   in call "rotate" [bf (rad2deg x), bf (rad2deg y), bf (rad2deg z)] [buildS3 obj]
 
 buildS3 (Rotate3V a v obj) = callNaked "rotate" [ "a=" <> bf (rad2deg a), "v=" <> bvect3 v ] [buildS3 obj]
 

--- a/Graphics/Implicit/ExtOpenScad/Primitives.hs
+++ b/Graphics/Implicit/ExtOpenScad/Primitives.hs
@@ -15,7 +15,7 @@
 -- Export one set containing all of the primitive modules.
 module Graphics.Implicit.ExtOpenScad.Primitives (primitiveModules) where
 
-import Prelude((.), Either(Left, Right), Bool(True, False), Maybe(Just, Nothing), ($), pure, either, id, (-), (==), (&&), (<), (*), cos, sin, pi, (/), (>), const, uncurry, fromInteger, round, (/=), (||), not, null, fmap, (<>), otherwise, error)
+import Prelude(Double, (.), Either(Left, Right), Bool(True, False), Maybe(Just, Nothing), ($), pure, either, id, (-), (==), (&&), (<), (*), cos, sin, pi, (/), (>), const, uncurry, fromInteger, round, (/=), (||), not, null, fmap, (<>), otherwise, error)
 
 import Graphics.Implicit.Definitions (ℝ, ℝ2, ℝ3, ℕ, SymbolicObj2, SymbolicObj3, ExtrudeRMScale(C1), fromℕtoℝ, isScaleID)
 
@@ -403,10 +403,10 @@ rotate = moduleWithSuite "rotate" $ \_ children -> do
     pure $ pure $ caseOType a $
                ( \θ  ->
                           objMap (Prim.rotate $ deg2rad θ) (Prim.rotate3V (deg2rad θ) v) children
-        ) <||> ( \(yz,zx,xy) ->
-            objMap (Prim.rotate $ deg2rad xy ) (Prim.rotate3 (deg2rad yz, deg2rad zx, deg2rad xy) ) children
-        ) <||> ( \(yz,zx) ->
-            objMap id (Prim.rotate3 (deg2rad yz, deg2rad zx, 0)) children
+        ) <||> ( \(yz :: Double,zx :: Double,xy :: Double) ->
+            objMap (Prim.rotate $ deg2rad xy ) (Prim.rotate3 (error "oops") ) children
+        ) <||> ( \(yz :: Double,zx :: Double) ->
+            objMap id (Prim.rotate3 (error "oops")) children
         ) <||> const []
       where
         deg2rad :: ℝ -> ℝ

--- a/Graphics/Implicit/ExtOpenScad/Primitives.hs
+++ b/Graphics/Implicit/ExtOpenScad/Primitives.hs
@@ -15,7 +15,7 @@
 -- Export one set containing all of the primitive modules.
 module Graphics.Implicit.ExtOpenScad.Primitives (primitiveModules) where
 
-import Prelude(Double, (.), Either(Left, Right), Bool(True, False), Maybe(Just, Nothing), ($), pure, either, id, (-), (==), (&&), (<), (*), cos, sin, pi, (/), (>), const, uncurry, fromInteger, round, (/=), (||), not, null, fmap, (<>), otherwise, error)
+import Prelude((.), Either(Left, Right), Bool(True, False), Maybe(Just, Nothing), ($), pure, either, id, (-), (==), (&&), (<), (*), cos, sin, pi, (/), (>), const, uncurry, fromInteger, round, (/=), (||), not, null, fmap, (<>), otherwise, error)
 
 import Graphics.Implicit.Definitions (ℝ, ℝ2, ℝ3, ℕ, SymbolicObj2, SymbolicObj3, ExtrudeRMScale(C1), fromℕtoℝ, isScaleID)
 
@@ -403,10 +403,10 @@ rotate = moduleWithSuite "rotate" $ \_ children -> do
     pure $ pure $ caseOType a $
                ( \θ  ->
                           objMap (Prim.rotate $ deg2rad θ) (Prim.rotate3V (deg2rad θ) v) children
-        ) <||> ( \(yz :: Double,zx :: Double,xy :: Double) ->
-            objMap (Prim.rotate $ deg2rad xy ) (Prim.rotate3 (error "oops") ) children
-        ) <||> ( \(yz :: Double,zx :: Double) ->
-            objMap id (Prim.rotate3 (error "oops")) children
+        ) <||> ( \(yz,zx,xy) ->
+            objMap (Prim.rotate $ deg2rad xy ) (Prim.rotate3 (deg2rad yz, deg2rad zx, deg2rad xy) ) children
+        ) <||> ( \(yz,zx) ->
+            objMap id (Prim.rotate3 (deg2rad yz, deg2rad zx, 0)) children
         ) <||> const []
       where
         deg2rad :: ℝ -> ℝ

--- a/Graphics/Implicit/MathUtil.hs
+++ b/Graphics/Implicit/MathUtil.hs
@@ -5,9 +5,10 @@
 {-# LANGUAGE FlexibleContexts #-}
 
 -- A module of math utilities.
-module Graphics.Implicit.MathUtil (rmax, rmaximum, rminimum, distFromLineSeg, pack, box3sWithin, reflect, quaternionToEuler, temp_viaV3) where
+module Graphics.Implicit.MathUtil (rmax, rmaximum, rminimum, distFromLineSeg, pack, box3sWithin, reflect, quaternionToEuler, alaV3) where
 
 -- Explicitly include what we need from Prelude.
+import GHC.Generics
 import Prelude (RealFloat, (>=), signum, atan2, Fractional, Bool(True, False), Ordering, (>), (<), (+), ($), (/), otherwise, not, (||), (&&), abs, (-), (*), sin, asin, pi, max, sqrt, min, compare, (<=), fst, snd, (<>), head, flip, maximum, minimum, (==))
 
 import Graphics.Implicit.Definitions (ℝ, ℝ2, ℝ3, Box2, (⋅))
@@ -176,8 +177,11 @@ quaternionToEuler (Quaternion w (V3 x y z))=
       yaw = atan2 siny_cosp cosy_cosp
    in (roll, pitch, yaw)
 
-temp_viaV3 :: (V3 a -> V3 a) -> (a, a, a) -> (a, a, a)
-temp_viaV3 f (x, y, z) =
+
+-- | Lift a function over 'V3' into a function over 'ℝ3'.
+alaV3 :: (V3 a -> V3 a) -> (a, a, a) -> (a, a, a)
+alaV3 f (x, y, z) =
   let V3 x' y' z' = f (V3 x y z)
   in (x', y', z')
+{-# INLINABLE alaV3 #-}
 

--- a/Graphics/Implicit/MathUtil.hs
+++ b/Graphics/Implicit/MathUtil.hs
@@ -5,11 +5,10 @@
 {-# LANGUAGE FlexibleContexts #-}
 
 -- A module of math utilities.
-module Graphics.Implicit.MathUtil (rmax, rmaximum, rminimum, distFromLineSeg, pack, box3sWithin, reflect, quaternionToEuler, alaV3) where
+module Graphics.Implicit.MathUtil (rmax, rmaximum, rminimum, distFromLineSeg, pack, box3sWithin, reflect, quaternionToEuler, alaV3, packV3, unpackV3) where
 
 -- Explicitly include what we need from Prelude.
-import GHC.Generics
-import Prelude (RealFloat, (>=), signum, atan2, Fractional, Bool(True, False), Ordering, (>), (<), (+), ($), (/), otherwise, not, (||), (&&), abs, (-), (*), sin, asin, pi, max, sqrt, min, compare, (<=), fst, snd, (<>), head, flip, maximum, minimum, (==))
+import Prelude ((.), RealFloat, (>=), signum, atan2, Fractional, Bool(True, False), Ordering, (>), (<), (+), ($), (/), otherwise, not, (||), (&&), abs, (-), (*), sin, asin, pi, max, sqrt, min, compare, (<=), fst, snd, (<>), head, flip, maximum, minimum, (==))
 
 import Graphics.Implicit.Definitions (ℝ, ℝ2, ℝ3, Box2, (⋅))
 
@@ -180,8 +179,14 @@ quaternionToEuler (Quaternion w (V3 x y z))=
 
 -- | Lift a function over 'V3' into a function over 'ℝ3'.
 alaV3 :: (V3 a -> V3 a) -> (a, a, a) -> (a, a, a)
-alaV3 f (x, y, z) =
-  let V3 x' y' z' = f (V3 x y z)
-  in (x', y', z')
+alaV3 f = unpackV3 . f . packV3
 {-# INLINABLE alaV3 #-}
+
+packV3 :: (a, a, a) -> V3 a
+packV3 (x, y, z) = V3 x y z
+{-# INLINABLE packV3 #-}
+
+unpackV3 :: V3 a -> (a, a, a)
+unpackV3 (V3 a a2 a3) = (a, a2, a3)
+{-# INLINABLE unpackV3 #-}
 

--- a/Graphics/Implicit/MathUtil.hs
+++ b/Graphics/Implicit/MathUtil.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 
 -- A module of math utilities.
-module Graphics.Implicit.MathUtil (rmax, rmaximum, rminimum, distFromLineSeg, pack, box3sWithin, reflect, quaternionToEuler) where
+module Graphics.Implicit.MathUtil (rmax, rmaximum, rminimum, distFromLineSeg, pack, box3sWithin, reflect, quaternionToEuler, temp_viaV3) where
 
 -- Explicitly include what we need from Prelude.
 import Prelude (RealFloat, (>=), signum, atan2, Fractional, Bool(True, False), Ordering, (>), (<), (+), ($), (/), otherwise, not, (||), (&&), abs, (-), (*), sin, asin, pi, max, sqrt, min, compare, (<=), fst, snd, (<>), head, flip, maximum, minimum, (==))
@@ -174,5 +174,10 @@ quaternionToEuler (Quaternion w (V3 x y z))=
                 False -> asin sinp
       roll = atan2 sinr_cosp cosr_cosp
       yaw = atan2 siny_cosp cosy_cosp
-   in (pitch, roll, yaw)
+   in (roll, pitch, yaw)
+
+temp_viaV3 :: (V3 a -> V3 a) -> (a, a, a) -> (a, a, a)
+temp_viaV3 f (x, y, z) =
+  let V3 x' y' z' = f (V3 x y z)
+  in (x', y', z')
 

--- a/Graphics/Implicit/MathUtil.hs
+++ b/Graphics/Implicit/MathUtil.hs
@@ -5,19 +5,20 @@
 {-# LANGUAGE FlexibleContexts #-}
 
 -- A module of math utilities.
-module Graphics.Implicit.MathUtil (rmax, rmaximum, rminimum, distFromLineSeg, pack, box3sWithin, reflect) where
+module Graphics.Implicit.MathUtil (rmax, rmaximum, rminimum, distFromLineSeg, pack, box3sWithin, reflect, quaternionToEuler) where
 
 -- Explicitly include what we need from Prelude.
-import Prelude (Fractional, Num, Bool, Ordering, (>), (<), (+), ($), (/), otherwise, not, (||), (&&), abs, (-), (*), sin, asin, pi, max, sqrt, min, compare, (<=), fst, snd, (<>), head, flip, maximum, minimum, (==))
+import Prelude (RealFloat, (>=), signum, atan2, Fractional, Bool(True, False), Ordering, (>), (<), (+), ($), (/), otherwise, not, (||), (&&), abs, (-), (*), sin, asin, pi, max, sqrt, min, compare, (<=), fst, snd, (<>), head, flip, maximum, minimum, (==))
 
 import Graphics.Implicit.Definitions (ℝ, ℝ2, ℝ3, Box2, (⋅))
 
 import Data.List (sort, sortBy, (!!))
 
-import Data.VectorSpace ((<.>), Scalar, (^*), InnerSpace, magnitude, normalized, (^-^), (^+^), (*^))
+import Data.VectorSpace ((<.>), Scalar, InnerSpace, magnitude, normalized, (^-^), (^+^), (*^))
 
 -- get the distance between two points.
 import Data.AffineSpace (distance)
+import Linear (V3(V3), Quaternion(Quaternion))
 
 -- | The distance a point p is from a line segment (a,b)
 distFromLineSeg :: ℝ2 -> (ℝ2, ℝ2) -> ℝ
@@ -157,4 +158,21 @@ reflect
     -> v
 reflect a v = v ^-^ (2 * ((v <.> a) / (a <.> a))) *^ a
 
+
+-- | Convert a 'Quaternion' to its constituent euler angles.
+--
+-- From https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles#Source_code_2
+quaternionToEuler :: RealFloat a => Quaternion a -> (a, a, a)
+quaternionToEuler (Quaternion w (V3 x y z))=
+  let sinr_cosp = 2 * (w * x + y * z)
+      cosr_cosp = 1 - 2 * (x * x + y * y)
+      sinp = 2 * (w * y - z * x);
+      siny_cosp = 2 * (w * z + x * y);
+      cosy_cosp = 1 - 2 * (y * y + z * z);
+      pitch = case abs sinp >= 1 of
+                True -> signum sinp * pi / 2
+                False -> asin sinp
+      roll = atan2 sinr_cosp cosr_cosp
+      yaw = atan2 siny_cosp cosy_cosp
+   in (pitch, roll, yaw)
 

--- a/Graphics/Implicit/ObjectUtil/GetBox3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetBox3.hs
@@ -7,7 +7,7 @@ module Graphics.Implicit.ObjectUtil.GetBox3 (getBox3) where
 
 import Prelude(Eq, Bool(False), Fractional, Either (Left, Right), (==), (||), max, (/), (-), (+), fmap, unzip, ($), (<$>), filter, not, (.), unzip3, minimum, maximum, min, (>), (&&), (*), (<), abs, either, error, const, otherwise, take, fst, snd)
 
-import Graphics.Implicit.Definitions (ℝ3, ℝ, Fastℕ, Box3, SymbolicObj3 (CubeR, Sphere, Cylinder, Complement3, UnionR3, IntersectR3, DifferenceR3, Translate3, Scale3, Rotate3, Rotate3V, Mirror3, Shell3, Outset3, EmbedBoxedObj3, ExtrudeR, ExtrudeOnEdgeOf, ExtrudeRM, RotateExtrude, ExtrudeRotateR), ExtrudeRMScale(C1, C2), (⋯*), fromFastℕtoℝ, fromFastℕ, toScaleFn)
+import Graphics.Implicit.Definitions (ℝ3, ℝ, Fastℕ, Box3, SymbolicObj3 (CubeR, Sphere, Cylinder, Complement3, UnionR3, IntersectR3, DifferenceR3, Translate3, Scale3, Rotate3, Mirror3, Shell3, Outset3, EmbedBoxedObj3, ExtrudeR, ExtrudeOnEdgeOf, ExtrudeRM, RotateExtrude, ExtrudeRotateR), ExtrudeRMScale(C1, C2), (⋯*), fromFastℕtoℝ, fromFastℕ, toScaleFn)
 
 import Graphics.Implicit.ObjectUtil.GetBox2 (getBox2, getBox2R)
 
@@ -109,7 +109,6 @@ getBox3 (Rotate3 q symbObj) =
           , alaV3 (Q.rotate q) (x1, y2, z2)
           , alaV3 (Q.rotate q) p2
           ]
-getBox3 (Rotate3V _ _ _) = error "this has always been broken"
 getBox3 (Mirror3 v symbObj) =
     let (p1@(x1, y1, z1), p2@(x2, y2, z2)) = getBox3 symbObj
      in pointsBox

--- a/Graphics/Implicit/ObjectUtil/GetBox3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetBox3.hs
@@ -12,7 +12,7 @@ import Graphics.Implicit.Definitions (ℝ3, ℝ, Fastℕ, Box3, SymbolicObj3 (Cu
 import Graphics.Implicit.ObjectUtil.GetBox2 (getBox2, getBox2R)
 
 import Data.VectorSpace ((^-^), (^+^))
-import Graphics.Implicit.MathUtil (reflect)
+import Graphics.Implicit.MathUtil (quaternionToEuler, reflect)
 
 -- FIXME: many variables are being ignored here. no rounding for intersect, or difference.. etc.
 
@@ -96,8 +96,8 @@ getBox3 (Scale3 s symbObj) =
         (sbx,sby,sbz) = s ⋯* b
     in
         ((min sax sbx, min say sby, min saz sbz), (max sax sbx, max say sby, max saz sbz))
-getBox3 (Rotate3 (a, b, c) symbObj) =
-    let
+getBox3 (Rotate3 q symbObj) =
+    let (a, b, c) = quaternionToEuler q
         ((x1, y1, z1), (x2, y2, z2)) = getBox3 symbObj
         rotate v1 w1 v2 w2 angle = getBox2(Rotate2 angle $ Translate2 (v1, w1) $ SquareR 0 (v2-v1, w2-w1))
         ((y1', z1'), (y2', z2')) = rotate y1 z1 y2 z2 a
@@ -107,7 +107,7 @@ getBox3 (Rotate3 (a, b, c) symbObj) =
     in
         ((minimum xs, minimum ys, minimum zs), (maximum xs, maximum ys, maximum zs))
 
-getBox3 (Rotate3V _ v symbObj) = getBox3 (Rotate3 v symbObj)
+getBox3 (Rotate3V _ _ _) = error "this has always been broken"
 getBox3 (Mirror3 v symbObj) =
     let (p1@(x1, y1, z1), p2@(x2, y2, z2)) = getBox3 symbObj
      in pointsBox

--- a/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
@@ -12,7 +12,7 @@ import Graphics.Implicit.Definitions (ℝ, ℕ, ℝ2, ℝ3, (⋯/), Obj3,
                                                    Outset3, CubeR, Sphere, Cylinder, Complement3, EmbedBoxedObj3, Rotate3V, Mirror3,
                                                    ExtrudeR, ExtrudeRM, ExtrudeOnEdgeOf, RotateExtrude, ExtrudeRotateR), fromℕtoℝ, toScaleFn, (⋅), minℝ)
 
-import Graphics.Implicit.MathUtil (quaternionToEuler, reflect, rmaximum, rminimum, rmax)
+import Graphics.Implicit.MathUtil (temp_viaV3, quaternionToEuler, reflect, rmaximum, rminimum, rmax)
 
 import Data.Maybe (fromMaybe, isJust)
 
@@ -24,6 +24,7 @@ import Data.Cross(cross3)
 
 -- Use getImplicit2 for handling extrusion of 2D shapes to 3D.
 import  Graphics.Implicit.ObjectUtil.GetImplicit2 (getImplicit2)
+import qualified Linear as Q
 
 default (ℝ)
 
@@ -79,6 +80,7 @@ getImplicit3 (Scale3 s@(sx,sy,sz) symbObj) =
     in
         \p -> k * obj (p ⋯/ s)
 getImplicit3 (Rotate3 q symbObj) =
+    -- getImplicit3 symbObj . temp_viaV3 (Q.rotate $ Q.conjugate q)
     let
         (yz, zx, xy) = quaternionToEuler q
         obj = getImplicit3 symbObj

--- a/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
@@ -12,7 +12,7 @@ import Graphics.Implicit.Definitions (ℝ, ℕ, ℝ2, ℝ3, (⋯/), Obj3,
                                                    Outset3, CubeR, Sphere, Cylinder, Complement3, EmbedBoxedObj3, Rotate3V, Mirror3,
                                                    ExtrudeR, ExtrudeRM, ExtrudeOnEdgeOf, RotateExtrude, ExtrudeRotateR), fromℕtoℝ, toScaleFn, (⋅), minℝ)
 
-import Graphics.Implicit.MathUtil (reflect, rmaximum, rminimum, rmax)
+import Graphics.Implicit.MathUtil (quaternionToEuler, reflect, rmaximum, rminimum, rmax)
 
 import Data.Maybe (fromMaybe, isJust)
 
@@ -78,8 +78,9 @@ getImplicit3 (Scale3 s@(sx,sy,sz) symbObj) =
         k = abs (sx*sy*sz) ** (1/3)
     in
         \p -> k * obj (p ⋯/ s)
-getImplicit3 (Rotate3 (yz, zx, xy) symbObj) =
+getImplicit3 (Rotate3 q symbObj) =
     let
+        (yz, zx, xy) = quaternionToEuler q
         obj = getImplicit3 symbObj
         rotateYZ :: ℝ -> (ℝ3 -> ℝ) -> (ℝ3 -> ℝ)
         rotateYZ θ obj' (x,y,z) = obj' ( x, y*cos θ + z*sin θ, z*cos θ - y*sin θ)

--- a/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
@@ -12,7 +12,7 @@ import Graphics.Implicit.Definitions (ℝ, ℕ, ℝ2, ℝ3, (⋯/), Obj3,
                                                    Outset3, CubeR, Sphere, Cylinder, Complement3, EmbedBoxedObj3, Rotate3V, Mirror3,
                                                    ExtrudeR, ExtrudeRM, ExtrudeOnEdgeOf, RotateExtrude, ExtrudeRotateR), fromℕtoℝ, toScaleFn, (⋅), minℝ)
 
-import Graphics.Implicit.MathUtil (temp_viaV3, quaternionToEuler, reflect, rmaximum, rminimum, rmax)
+import Graphics.Implicit.MathUtil (alaV3, reflect, rmaximum, rminimum, rmax)
 
 import Data.Maybe (fromMaybe, isJust)
 
@@ -80,18 +80,7 @@ getImplicit3 (Scale3 s@(sx,sy,sz) symbObj) =
     in
         \p -> k * obj (p ⋯/ s)
 getImplicit3 (Rotate3 q symbObj) =
-    -- getImplicit3 symbObj . temp_viaV3 (Q.rotate $ Q.conjugate q)
-    let
-        (yz, zx, xy) = quaternionToEuler q
-        obj = getImplicit3 symbObj
-        rotateYZ :: ℝ -> (ℝ3 -> ℝ) -> (ℝ3 -> ℝ)
-        rotateYZ θ obj' (x,y,z) = obj' ( x, y*cos θ + z*sin θ, z*cos θ - y*sin θ)
-        rotateZX :: ℝ -> (ℝ3 -> ℝ) -> (ℝ3 -> ℝ)
-        rotateZX θ obj' (x,y,z) = obj' ( x*cos θ - z*sin θ, y, z*cos θ + x*sin θ)
-        rotateXY :: ℝ -> (ℝ3 -> ℝ) -> (ℝ3 -> ℝ)
-        rotateXY θ obj' (x,y,z) = obj' ( x*cos θ + y*sin θ, y*cos θ - x*sin θ, z)
-    in
-        rotateXY xy $ rotateZX zx $ rotateYZ yz obj
+    getImplicit3 symbObj . alaV3 (Q.rotate $ Q.conjugate q)
 getImplicit3 (Rotate3V θ axis symbObj) =
     let
         axis' = normalized axis

--- a/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
@@ -9,22 +9,19 @@ import Prelude (Either(Left, Right), abs, (-), (/), (*), sqrt, (+), atan2, max, 
 
 import Graphics.Implicit.Definitions (ℝ, ℕ, ℝ2, ℝ3, (⋯/), Obj3,
                                       SymbolicObj3(Shell3, UnionR3, IntersectR3, DifferenceR3, Translate3, Scale3, Rotate3,
-                                                   Outset3, CubeR, Sphere, Cylinder, Complement3, EmbedBoxedObj3, Rotate3V, Mirror3,
-                                                   ExtrudeR, ExtrudeRM, ExtrudeOnEdgeOf, RotateExtrude, ExtrudeRotateR), fromℕtoℝ, toScaleFn, (⋅), minℝ)
+                                                   Outset3, CubeR, Sphere, Cylinder, Complement3, EmbedBoxedObj3, Mirror3,
+                                                   ExtrudeR, ExtrudeRM, ExtrudeOnEdgeOf, RotateExtrude, ExtrudeRotateR), fromℕtoℝ, toScaleFn, minℝ)
 
 import Graphics.Implicit.MathUtil (alaV3, reflect, rmaximum, rminimum, rmax)
 
 import Data.Maybe (fromMaybe, isJust)
+import qualified Linear as Q
 
 import qualified Data.Either as Either (either)
 
-import Data.VectorSpace ((^*), normalized)
-
-import Data.Cross(cross3)
-
 -- Use getImplicit2 for handling extrusion of 2D shapes to 3D.
 import  Graphics.Implicit.ObjectUtil.GetImplicit2 (getImplicit2)
-import qualified Linear as Q
+import Data.VectorSpace (AdditiveGroup((^-^)))
 
 default (ℝ)
 
@@ -72,7 +69,7 @@ getImplicit3 (Translate3 v symbObj) =
     let
         obj = getImplicit3 symbObj
     in
-        \p -> obj (p - v)
+        \p -> obj (p ^-^ v)
 getImplicit3 (Scale3 s@(sx,sy,sz) symbObj) =
     let
         obj = getImplicit3 symbObj
@@ -81,15 +78,6 @@ getImplicit3 (Scale3 s@(sx,sy,sz) symbObj) =
         \p -> k * obj (p ⋯/ s)
 getImplicit3 (Rotate3 q symbObj) =
     getImplicit3 symbObj . alaV3 (Q.rotate $ Q.conjugate q)
-getImplicit3 (Rotate3V θ axis symbObj) =
-    let
-        axis' = normalized axis
-        obj = getImplicit3 symbObj
-    in
-        \v -> obj $
-            v ^* cos θ
-            - (axis' `cross3` v) ^* sin θ
-            + (axis' ^* (axis' ⋅ (v ^* (1 - cos θ))))
 getImplicit3 (Mirror3 v symbObj) =
     getImplicit3 symbObj . reflect v
 -- Boundary mods

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -84,6 +84,7 @@ import Graphics.Implicit.Definitions (both, allthree, ℝ, ℝ2, ℝ3, Box2,
 import Graphics.Implicit.MathUtil   (pack)
 import Graphics.Implicit.ObjectUtil (getBox2, getBox3, getImplicit2, getImplicit3)
 import Data.VectorSpace (AdditiveGroup((^-^)))
+import Linear (Quaternion)
 
 -- $ 3D Primitives
 
@@ -318,7 +319,7 @@ extrudeOnEdgeOf = ExtrudeOnEdgeOf
 
 -- | Rotate a 3D object via an Euler angle, measured in radians, along the
 -- world axis.
-rotate3 :: ℝ3 -> SymbolicObj3 -> SymbolicObj3
+rotate3 :: Quaternion ℝ -> SymbolicObj3 -> SymbolicObj3
 rotate3 = Rotate3
 
 -- | Rotate a 3D object along an arbitrary axis.

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -69,7 +69,6 @@ import Graphics.Implicit.Definitions (both, allthree, ℝ, ℝ2, ℝ3, Box2,
                                                    Mirror3,
                                                    Scale3,
                                                    Rotate3,
-                                                   Rotate3V,
                                                    Outset3,
                                                    Shell3,
                                                    EmbedBoxedObj3,
@@ -81,10 +80,10 @@ import Graphics.Implicit.Definitions (both, allthree, ℝ, ℝ2, ℝ3, Box2,
                                                   ),
                                       ExtrudeRMScale
                                      )
-import Graphics.Implicit.MathUtil   (pack)
+import Graphics.Implicit.MathUtil   (packV3, pack)
 import Graphics.Implicit.ObjectUtil (getBox2, getBox3, getImplicit2, getImplicit3)
 import Data.VectorSpace (AdditiveGroup((^-^)))
-import Linear (Quaternion)
+import Linear (axisAngle, Quaternion)
 
 -- $ 3D Primitives
 
@@ -328,7 +327,7 @@ rotate3V
     -> ℝ3  -- ^ Axis of rotation
     -> SymbolicObj3
     -> SymbolicObj3
-rotate3V = Rotate3V
+rotate3V w xyz = Rotate3 $ axisAngle (packV3 xyz) w
 
 -- FIXME: shouldn't this pack into a 3d area, or have a 3d equivalent?
 -- | Attempt to pack multiple 3D objects into a fixed area. The @z@ coordinate

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -30,6 +30,7 @@ module Graphics.Implicit.Primitives (
                                      polygonR,
                                      rotateExtrude,
                                      rotate3,
+                                     rotateQ,
                                      rotate3V,
                                      pack3,
                                      rotate,
@@ -38,7 +39,7 @@ module Graphics.Implicit.Primitives (
                                      Object
                                     ) where
 
-import Prelude((/), (.), mempty, negate, Bool(True, False), Maybe(Just, Nothing), Either, fmap, ($))
+import Prelude((*), (/), (.), mempty, negate, Bool(True, False), Maybe(Just, Nothing), Either, fmap, ($))
 
 import Graphics.Implicit.Definitions (both, allthree, ℝ, ℝ2, ℝ3, Box2,
                                       SymbolicObj2(
@@ -83,7 +84,7 @@ import Graphics.Implicit.Definitions (both, allthree, ℝ, ℝ2, ℝ3, Box2,
 import Graphics.Implicit.MathUtil   (packV3, pack)
 import Graphics.Implicit.ObjectUtil (getBox2, getBox3, getImplicit2, getImplicit3)
 import Data.VectorSpace (AdditiveGroup((^-^)))
-import Linear (axisAngle, Quaternion)
+import Linear (V3(V3), axisAngle, Quaternion)
 
 -- $ 3D Primitives
 
@@ -318,8 +319,18 @@ extrudeOnEdgeOf = ExtrudeOnEdgeOf
 
 -- | Rotate a 3D object via an Euler angle, measured in radians, along the
 -- world axis.
-rotate3 :: Quaternion ℝ -> SymbolicObj3 -> SymbolicObj3
-rotate3 = Rotate3
+rotate3 :: ℝ3 -> SymbolicObj3 -> SymbolicObj3
+rotate3 (pitch, roll, yaw)
+  = Rotate3
+  $ axisAngle (V3 0 0 1) yaw
+  * axisAngle (V3 0 1 0) roll
+  * axisAngle (V3 1 0 0) pitch
+
+rotateQ
+    :: Quaternion ℝ
+    -> SymbolicObj3
+    -> SymbolicObj3
+rotateQ = Rotate3
 
 -- | Rotate a 3D object along an arbitrary axis.
 rotate3V

--- a/implicit.cabal
+++ b/implicit.cabal
@@ -92,7 +92,8 @@ Library
                   storable-endian,
                   JuicyPixels,
                   transformers,
-                  mtl
+                  mtl,
+                  linear
     Exposed-modules:
                     Graphics.Implicit
                     Graphics.Implicit.Definitions


### PR DESCRIPTION
This PR replaces the 3d implementations of rotation with one based on quaternions. There were previously four separate implementations of rotation, and at least one (#313) but more likely two were wrong.

By using @ekmett's industrial-strength linear algebra package, we can consolidate all four implementations into two library calls. This package is already in the transitive dependencies, and is a step towards #286.

The result: we now have the identity `getBox (rotate3 (2 * pi, 0, 0) x) = getBox x`  (well, with error `O(1e-16)`).

Furthermore, it removes the `Rotate3V` primitive, which was just a quaternion encoding in disguise.

Fixes #313. 