### PR TITLE
Fix monoid instances; add tests of algebraic properties for symbolic objects

### DIFF
--- a/Graphics/Implicit.hs
+++ b/Graphics/Implicit.hs
@@ -25,7 +25,9 @@ module Graphics.Implicit (
       P.intersectR,
       P.differenceR,
       P.implicit,
-      P.shell
+      P.shell,
+      P.emptySpace,
+      P.fullSpace
     ),
   P.union,
   P.intersect,
@@ -82,7 +84,7 @@ import Prelude(FilePath, IO)
 
 -- The primitive objects, and functions for manipulating them.
 -- MAYBEFIXME: impliment slice operation, regularPolygon and zsurface primitives.
-import Graphics.Implicit.Primitives as P (rectR, rect3R, translate, scale, mirror, complement, union, intersect, difference, unionR, intersectR, differenceR, shell, extrudeR, extrudeRM, extrudeOnEdgeOf, sphere, cubeR, circle, cylinder, cylinder2, squareR, polygonR, rotateExtrude, rotate3, rotate3V, pack3, rotate, pack2, implicit, Object)
+import Graphics.Implicit.Primitives as P (rectR, rect3R, translate, scale, mirror, complement, union, intersect, difference, unionR, intersectR, differenceR, shell, extrudeR, extrudeRM, extrudeOnEdgeOf, sphere, cubeR, circle, cylinder, cylinder2, squareR, polygonR, rotateExtrude, rotate3, rotate3V, pack3, rotate, pack2, implicit, fullSpace, emptySpace, Object)
 
 -- The Extended OpenScad interpreter.
 import Graphics.Implicit.ExtOpenScad as E (runOpenscad)

--- a/Graphics/Implicit/Definitions.hs
+++ b/Graphics/Implicit/Definitions.hs
@@ -336,6 +336,8 @@ instance Semigroup SymbolicObj3 where
   _ <> Full3 = Full3
   -- Otherwise don't introduce a UnionR3 constructor if we can avoid it
   UnionR3 0 as <> UnionR3 0 bs = UnionR3 0 $ as <> bs
+  a <> UnionR3 0 bs = UnionR3 0 $ a : bs
+  UnionR3 0 as <> b = UnionR3 0 $ as <> [b]
   a <> b = UnionR3 0 [a, b]
 
 -- | Monoid under 'Graphic.Implicit.Primitives.union'.

--- a/Graphics/Implicit/Definitions.hs
+++ b/Graphics/Implicit/Definitions.hs
@@ -54,6 +54,8 @@ module Graphics.Implicit.Definitions (
         Outset2,
         EmbedBoxedObj2),
     SymbolicObj3(
+        Empty3,
+        Full3,
         CubeR,
         Sphere,
         Cylinder,
@@ -84,7 +86,7 @@ where
 
 import GHC.Generics (Generic)
 
-import Prelude (Semigroup((<>)), Monoid (mempty), Show, Double, Either(Left, Right), Bool(True, False), show, (*), (/), fromIntegral, Float, realToFrac)
+import Prelude (($), Semigroup((<>)), Monoid (mempty), Show, Double, Either(Left, Right), Bool(True, False), show, (*), (/), fromIntegral, Float, realToFrac)
 
 import Data.Maybe (Maybe)
 
@@ -285,7 +287,9 @@ instance Monoid SymbolicObj2 where
 -- | A symbolic 3D format!
 data SymbolicObj3 =
     -- Primitives
-      CubeR ℝ ℝ3 -- rounding, size.
+      Empty3  -- ^ The empty object
+    | Full3   -- ^ The entirely full object
+    | CubeR ℝ ℝ3 -- rounding, size.
     | Sphere ℝ -- radius
     | Cylinder ℝ ℝ ℝ --
     -- (Rounded) CSG
@@ -324,11 +328,19 @@ data SymbolicObj3 =
 
 -- | Semigroup under 'Graphic.Implicit.Primitives.union'.
 instance Semigroup SymbolicObj3 where
+  -- Empty3 is an identity for (<>)
+  Empty3 <> a = a
+  a <> Empty3 = a
+  -- Full3 is an annhilator
+  Full3 <> _ = Full3
+  _ <> Full3 = Full3
+  -- Otherwise don't introduce a UnionR3 constructor if we can avoid it
+  UnionR3 0 as <> UnionR3 0 bs = UnionR3 0 $ as <> bs
   a <> b = UnionR3 0 [a, b]
 
 -- | Monoid under 'Graphic.Implicit.Primitives.union'.
 instance Monoid SymbolicObj3 where
-  mempty = CubeR 0 (0, 0, 0)
+  mempty = Empty3
 
 data ExtrudeRMScale =
       C1 ℝ                  -- constant ℝ

--- a/Graphics/Implicit/Definitions.hs
+++ b/Graphics/Implicit/Definitions.hs
@@ -39,6 +39,8 @@ module Graphics.Implicit.Definitions (
     BoxedObj2,
     BoxedObj3,
     SymbolicObj2(
+        Empty2,
+        Full2,
         SquareR,
         Circle,
         PolygonR,
@@ -256,7 +258,9 @@ type BoxedObj3 = Boxed3 Obj3
 --   cases.
 data SymbolicObj2 =
     -- Primitives
-      SquareR ℝ ℝ2    -- rounding, size.
+      Empty2  -- ^ The empty object
+    | Full2   -- ^ The entirely full object
+    | SquareR ℝ ℝ2    -- rounding, size.
     | Circle ℝ        -- radius.
     | PolygonR ℝ [ℝ2] -- rounding, points.
     -- (Rounded) CSG
@@ -278,11 +282,22 @@ data SymbolicObj2 =
 
 -- | Semigroup under 'Graphic.Implicit.Primitives.union'.
 instance Semigroup SymbolicObj2 where
+  -- Empty2 is an identity for (<>)
+  Empty2 <> a = a
+  a <> Empty2 = a
+  -- Full2 is an annhilator
+  Full2 <> _ = Full2
+  _ <> Full2 = Full2
+  -- Otherwise don't introduce a UnionR2 constructor if we can avoid it
+  UnionR2 0 as <> UnionR2 0 bs = UnionR2 0 $ as <> bs
+  a <> UnionR2 0 bs = UnionR2 0 $ a : bs
+  UnionR2 0 as <> b = UnionR2 0 $ as <> [b]
   a <> b = UnionR2 0 [a, b]
+
 
 -- | Monoid under 'Graphic.Implicit.Primitives.union'.
 instance Monoid SymbolicObj2 where
-  mempty = SquareR 0 (0, 0)
+  mempty = Empty2
 
 -- | A symbolic 3D format!
 data SymbolicObj3 =

--- a/Graphics/Implicit/Export/SymbolicFormats.hs
+++ b/Graphics/Implicit/Export/SymbolicFormats.hs
@@ -10,7 +10,7 @@ module Graphics.Implicit.Export.SymbolicFormats (scad2, scad3) where
 
 import Prelude(fmap, Either(Left, Right), ($), (*), ($!), (-), (/), pi, error, (+), (==), take, floor, (&&), const, pure, (<>), sequenceA, (<$>))
 
-import Graphics.Implicit.Definitions(ℝ2, ℝ3, ℝ, SymbolicObj2(SquareR, Circle, PolygonR, Complement2, UnionR2, DifferenceR2, IntersectR2, Translate2, Scale2, Rotate2, Mirror2, Outset2, Shell2, EmbedBoxedObj2), SymbolicObj3(CubeR, Sphere, Cylinder, Complement3, UnionR3, IntersectR3, DifferenceR3, Translate3, Scale3, Rotate3, Mirror3, Outset3, Shell3, ExtrudeR, ExtrudeRotateR, ExtrudeRM, EmbedBoxedObj3, RotateExtrude, ExtrudeOnEdgeOf), isScaleID)
+import Graphics.Implicit.Definitions(ℝ2, ℝ3, ℝ, SymbolicObj2(Empty2, Full2, SquareR, Circle, PolygonR, Complement2, UnionR2, DifferenceR2, IntersectR2, Translate2, Scale2, Rotate2, Mirror2, Outset2, Shell2, EmbedBoxedObj2), SymbolicObj3(Empty3, Full3, CubeR, Sphere, Cylinder, Complement3, UnionR3, IntersectR3, DifferenceR3, Translate3, Scale3, Rotate3, Mirror3, Outset3, Shell3, ExtrudeR, ExtrudeRotateR, ExtrudeRM, EmbedBoxedObj3, RotateExtrude, ExtrudeOnEdgeOf), isScaleID)
 import Graphics.Implicit.Export.TextBuilderUtils(Text, Builder, toLazyText, fromLazyText, bf)
 
 import Control.Monad.Reader (Reader, runReader, ask)
@@ -58,6 +58,10 @@ bvect2 (x, y) = "[" <> fold (intersperse "," [bf x, bf y]) <> "]"
 
 -- | First, the 3D objects.
 buildS3 :: SymbolicObj3 -> Reader ℝ Builder
+
+buildS3 Empty3 = call "union" [] []
+
+buildS3 Full3 = buildS3 $ Complement3 Empty3
 
 buildS3 (CubeR r (w,d,h)) | r == 0 = call "cube" [bf w, bf d, bf h] []
 
@@ -131,7 +135,9 @@ buildS3(ExtrudeOnEdgeOf _ _) = error "cannot provide roundness when exporting op
 
 buildS2 :: SymbolicObj2 -> Reader ℝ Builder
 
-buildS2 (SquareR r (w,h)) | r == 0 = call "cube" [bf w, bf h] []
+buildS2 Empty2 = call "union" [] []
+
+buildS2 Full2 = buildS2 $ Complement2 Empty2
 
 buildS2 (Circle r) = call "circle" [bf r] []
 

--- a/Graphics/Implicit/MathUtil.hs
+++ b/Graphics/Implicit/MathUtil.hs
@@ -194,6 +194,10 @@ unpackV3 :: V3 a -> (a, a, a)
 unpackV3 (V3 a a2 a3) = (a, a2, a3)
 {-# INLINABLE unpackV3 #-}
 
+
+------------------------------------------------------------------------------
+-- | Haskell's standard library doesn't make floating-point infinity available
+-- in any convenient way, so we define it here.
 infty :: (Fractional t) => t
 infty = 1/0
 

--- a/Graphics/Implicit/MathUtil.hs
+++ b/Graphics/Implicit/MathUtil.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 
 -- A module of math utilities.
-module Graphics.Implicit.MathUtil (rmax, rmaximum, rminimum, distFromLineSeg, pack, box3sWithin, reflect, quaternionToEuler, alaV3, packV3, unpackV3) where
+module Graphics.Implicit.MathUtil (rmax, rmaximum, rminimum, distFromLineSeg, pack, box3sWithin, reflect, quaternionToEuler, alaV3, packV3, unpackV3, infty) where
 
 -- Explicitly include what we need from Prelude.
 import Prelude (Fractional, Bool(True, False), RealFloat, Ordering, (>), (<), (+), ($), (/), otherwise, not, (||), (&&), abs, (-), (*), sin, asin, pi, max, sqrt, min, compare, (<=), fst, snd, (<>), head, flip, maximum, minimum, (==), (>=), signum, atan2, (.))
@@ -193,4 +193,7 @@ packV3 (x, y, z) = V3 x y z
 unpackV3 :: V3 a -> (a, a, a)
 unpackV3 (V3 a a2 a3) = (a, a2, a3)
 {-# INLINABLE unpackV3 #-}
+
+infty :: (Fractional t) => t
+infty = 1/0
 

--- a/Graphics/Implicit/MathUtil.hs
+++ b/Graphics/Implicit/MathUtil.hs
@@ -48,6 +48,8 @@ box3sWithin r ((ax1, ay1, az1),(ax2, ay2, az2)) ((bx1, by1, bz1),(bx2, by2, bz2)
 -- Consider  max(x,y) = 0, the generated curve
 -- has a square-like corner. We replace it with a
 -- quarter of a circle
+--
+-- NOTE: rmax is not associative!
 rmax ::
     ℝ     -- ^ radius
     -> ℝ  -- ^ first number to round maximum
@@ -60,6 +62,8 @@ rmax r x y
                 else max x y
 
 -- | Rounded minimum
+--
+-- NOTE: rmin is not associative!
 rmin ::
     ℝ     -- ^ radius
     -> ℝ  -- ^ first number to round minimum

--- a/Graphics/Implicit/ObjectUtil/GetBox2.hs
+++ b/Graphics/Implicit/ObjectUtil/GetBox2.hs
@@ -4,16 +4,16 @@
 
 module Graphics.Implicit.ObjectUtil.GetBox2 (getBox2, getBox2R) where
 
-import Prelude(Bool, Fractional, Eq, (==), (||), unzip, minimum, maximum, ($), filter, not, (.), (/), fmap, (-), (+), (*), cos, sin, sqrt, min, max, (<), (<>), pi, atan2, (==), (>), show, (&&), otherwise, error)
+import Prelude(Bool, Eq, (==), (||), unzip, minimum, maximum, ($), filter, not, (.), (/), fmap, (-), (+), (*), cos, sin, sqrt, min, max, (<), (<>), pi, atan2, (==), (>), show, (&&), otherwise, error)
 
 import Graphics.Implicit.Definitions (ℝ, ℝ2, Box2, (⋯*),
-                                      SymbolicObj2(Shell2, Outset2, Circle, Translate2, Rotate2, UnionR2, Scale2, SquareR,
+                                      SymbolicObj2(Empty2, Full2, Shell2, Outset2, Circle, Translate2, Rotate2, UnionR2, Scale2, SquareR,
                                                    PolygonR, Complement2, DifferenceR2, IntersectR2, EmbedBoxedObj2, Mirror2), minℝ)
 
 import Data.VectorSpace ((^-^), (^+^))
 
 import Data.Fixed (mod')
-import Graphics.Implicit.MathUtil (reflect)
+import Graphics.Implicit.MathUtil (infty, reflect)
 
 -- | An empty box.
 emptyBox :: Box2
@@ -67,15 +67,14 @@ outsetBox r (a,b) =
 -- Get a Box2 around the given object.
 getBox2 :: SymbolicObj2 -> Box2
 -- Primitives
+getBox2 Empty2 = emptyBox
+getBox2 Full2  = ((-infty, -infty), (infty, infty))
 getBox2 (SquareR _ size) = ((0, 0), size)
 getBox2 (Circle r) = ((-r, -r), (r,r))
 getBox2 (PolygonR _ points) = pointsBox points
 -- (Rounded) CSG
 getBox2 (Complement2 _) =
     ((-infty, -infty), (infty, infty))
-        where
-          infty :: (Fractional t) => t
-          infty = 1/0
 getBox2 (UnionR2 r symbObjs) =
   outsetBox r $ unionBoxes (fmap getBox2 symbObjs)
 getBox2 (DifferenceR2 _ symbObj _) = getBox2 symbObj

--- a/Graphics/Implicit/ObjectUtil/GetBox3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetBox3.hs
@@ -5,14 +5,14 @@
 
 module Graphics.Implicit.ObjectUtil.GetBox3 (getBox3) where
 
-import Prelude(Eq, Bool(False), Fractional, Either (Left, Right), (==), (||), max, (/), (-), (+), fmap, unzip, ($), (<$>), filter, not, (.), unzip3, minimum, maximum, min, (>), (&&), (*), (<), abs, either, error, const, otherwise, take, fst, snd)
+import Prelude(Eq, Bool(False), Either (Left, Right), (==), (||), max, (/), (-), (+), fmap, unzip, ($), (<$>), filter, not, (.), unzip3, minimum, maximum, min, (>), (&&), (*), (<), abs, either, error, const, otherwise, take, fst, snd)
 
 import Graphics.Implicit.Definitions (ℝ3, ℝ, Fastℕ, Box3, SymbolicObj3 (Empty3, Full3, CubeR, Sphere, Cylinder, Complement3, UnionR3, IntersectR3, DifferenceR3, Translate3, Scale3, Rotate3, Mirror3, Shell3, Outset3, EmbedBoxedObj3, ExtrudeR, ExtrudeOnEdgeOf, ExtrudeRM, RotateExtrude, ExtrudeRotateR), ExtrudeRMScale(C1, C2), (⋯*), fromFastℕtoℝ, fromFastℕ, toScaleFn)
 
 import Graphics.Implicit.ObjectUtil.GetBox2 (getBox2, getBox2R)
 
 import Data.VectorSpace ((^-^), (^+^))
-import Graphics.Implicit.MathUtil (alaV3, reflect)
+import Graphics.Implicit.MathUtil (infty, alaV3, reflect)
 import qualified Linear.Quaternion as Q
 
 -- FIXME: many variables are being ignored here. no rounding for intersect, or difference.. etc.
@@ -40,9 +40,6 @@ isEmpty ((a,b,c),(d,e,f)) = a==d || b==e || c==f
 outsetBox :: ℝ -> Box3 -> Box3
 outsetBox r (a,b) =
     (a ^-^ (r,r,r), b ^+^ (r,r,r))
-
-infty :: Fractional t => t
-infty = 1 / 0
 
 -- Get a Box3 around the given object.
 getBox3 :: SymbolicObj3 -> Box3

--- a/Graphics/Implicit/ObjectUtil/GetBox3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetBox3.hs
@@ -7,7 +7,7 @@ module Graphics.Implicit.ObjectUtil.GetBox3 (getBox3) where
 
 import Prelude(Eq, Bool(False), Fractional, Either (Left, Right), (==), (||), max, (/), (-), (+), fmap, unzip, ($), (<$>), filter, not, (.), unzip3, minimum, maximum, min, (>), (&&), (*), (<), abs, either, error, const, otherwise, take, fst, snd)
 
-import Graphics.Implicit.Definitions (ℝ3, ℝ, Fastℕ, Box3, SymbolicObj3 (CubeR, Sphere, Cylinder, Complement3, UnionR3, IntersectR3, DifferenceR3, Translate3, Scale3, Rotate3, Mirror3, Shell3, Outset3, EmbedBoxedObj3, ExtrudeR, ExtrudeOnEdgeOf, ExtrudeRM, RotateExtrude, ExtrudeRotateR), ExtrudeRMScale(C1, C2), (⋯*), fromFastℕtoℝ, fromFastℕ, toScaleFn)
+import Graphics.Implicit.Definitions (ℝ3, ℝ, Fastℕ, Box3, SymbolicObj3 (Empty3, Full3, CubeR, Sphere, Cylinder, Complement3, UnionR3, IntersectR3, DifferenceR3, Translate3, Scale3, Rotate3, Mirror3, Shell3, Outset3, EmbedBoxedObj3, ExtrudeR, ExtrudeOnEdgeOf, ExtrudeRM, RotateExtrude, ExtrudeRotateR), ExtrudeRMScale(C1, C2), (⋯*), fromFastℕtoℝ, fromFastℕ, toScaleFn)
 
 import Graphics.Implicit.ObjectUtil.GetBox2 (getBox2, getBox2R)
 
@@ -41,18 +41,20 @@ outsetBox :: ℝ -> Box3 -> Box3
 outsetBox r (a,b) =
     (a ^-^ (r,r,r), b ^+^ (r,r,r))
 
+infty :: Fractional t => t
+infty = 1 / 0
+
 -- Get a Box3 around the given object.
 getBox3 :: SymbolicObj3 -> Box3
 -- Primitives
+getBox3 Empty3 = ((0, 0, 0), (0, 0, 0))
+getBox3 Full3 = ((-infty, -infty, -infty), (infty, infty, infty))
 getBox3 (CubeR _ size) = ((0, 0, 0), size)
 getBox3 (Sphere r) = ((-r, -r, -r), (r,r,r))
 getBox3 (Cylinder h r1 r2) = ( (-r,-r,0), (r,r,h) ) where r = max r1 r2
 -- (Rounded) CSG
-getBox3 (Complement3 _) =
+getBox3 (Complement3 _) =  -- TODO(sandy): Not true of Full3
     ((-infty, -infty, -infty), (infty, infty, infty))
-        where
-          infty :: (Fractional t) => t
-          infty = 1/0
 getBox3 (UnionR3 r symbObjs) = outsetBox r ((left,bot,inward), (right,top,out))
     where
         boxes = fmap getBox3 symbObjs

--- a/Graphics/Implicit/ObjectUtil/GetImplicit2.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit2.hs
@@ -4,17 +4,19 @@
 
 module Graphics.Implicit.ObjectUtil.GetImplicit2 (getImplicit2) where
 
-import Prelude(abs, (-), (/), sqrt, (*), (+), mod, length, fmap, (<=), (&&), (>=), (||), odd, ($), (>), filter, (<), minimum, max, cos, sin, tail, (.))
+import Prelude(const, abs, (-), (/), sqrt, (*), (+), mod, length, fmap, (<=), (&&), (>=), (||), odd, ($), (>), filter, (<), minimum, max, cos, sin, tail, (.))
 
-import Graphics.Implicit.Definitions (ℝ, ℕ, ℝ2, (⋯/), Obj2, SymbolicObj2(SquareR, Circle, PolygonR, Complement2, UnionR2, DifferenceR2, IntersectR2, Translate2, Scale2, Rotate2, Mirror2, Shell2, Outset2, EmbedBoxedObj2))
+import Graphics.Implicit.Definitions (ℝ, ℕ, ℝ2, (⋯/), Obj2, SymbolicObj2(Empty2, Full2, SquareR, Circle, PolygonR, Complement2, UnionR2, DifferenceR2, IntersectR2, Translate2, Scale2, Rotate2, Mirror2, Shell2, Outset2, EmbedBoxedObj2))
 
-import Graphics.Implicit.MathUtil (reflect, rminimum, rmaximum, distFromLineSeg)
+import Graphics.Implicit.MathUtil (infty, reflect, rminimum, rmaximum, distFromLineSeg)
 
 import Data.VectorSpace ((^-^))
 import Data.List (nub, genericIndex, genericLength)
 
 getImplicit2 :: SymbolicObj2 -> Obj2
 -- Primitives
+getImplicit2 Empty2 = const infty
+getImplicit2 Full2 = const $ -infty
 getImplicit2 (SquareR r (dx, dy)) =
     \(x,y) -> let
     in
@@ -51,6 +53,7 @@ getImplicit2 (UnionR2 r symbObjs) =
         objs = fmap getImplicit2 symbObjs
     in
         rminimum r $ fmap ($p) objs
+getImplicit2 (DifferenceR2 _ symbObj []) = getImplicit2 symbObj
 getImplicit2 (DifferenceR2 r symbObj symbObjs) =
     let
         objs = fmap getImplicit2 symbObjs

--- a/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
@@ -5,14 +5,14 @@
 
 module Graphics.Implicit.ObjectUtil.GetImplicit3 (getImplicit3) where
 
-import Prelude (const, Fractional, Either(Left, Right), abs, (-), (/), (*), sqrt, (+), atan2, max, cos, fmap, minimum, ($), (**), sin, pi, (.), Bool(True, False), ceiling, floor, pure, error, (>), (&&), (<), (==), otherwise, (<$>))
+import Prelude (const, Either(Left, Right), abs, (-), (/), (*), sqrt, (+), atan2, max, cos, fmap, minimum, ($), (**), sin, pi, (.), Bool(True, False), ceiling, floor, pure, error, (>), (&&), (<), (==), otherwise, (<$>))
 
 import Graphics.Implicit.Definitions (ℝ, ℕ, ℝ2, ℝ3, (⋯/), Obj3,
                                       SymbolicObj3(Empty3, Full3, Shell3, UnionR3, IntersectR3, DifferenceR3, Translate3, Scale3, Rotate3,
                                                    Outset3, CubeR, Sphere, Cylinder, Complement3, EmbedBoxedObj3, Mirror3,
                                                    ExtrudeR, ExtrudeRM, ExtrudeOnEdgeOf, RotateExtrude, ExtrudeRotateR), fromℕtoℝ, toScaleFn, minℝ)
 
-import Graphics.Implicit.MathUtil (alaV3, reflect, rmaximum, rminimum, rmax)
+import Graphics.Implicit.MathUtil (infty, alaV3, reflect, rmaximum, rminimum, rmax)
 
 import Data.Maybe (fromMaybe, isJust)
 import qualified Linear as Q
@@ -24,9 +24,6 @@ import  Graphics.Implicit.ObjectUtil.GetImplicit2 (getImplicit2)
 import Data.VectorSpace (AdditiveGroup((^-^)))
 
 default (ℝ)
-
-infty :: Fractional t => t
-infty = 1 / 0
 
 -- Get a function that describes the surface of the object.
 getImplicit3 :: SymbolicObj3 -> Obj3

--- a/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
@@ -68,6 +68,8 @@ getImplicit3 (UnionR3 r symbObjs) =
 getImplicit3 (IntersectR3 r symbObjs) =
   \p -> rmaximum r $ fmap ($p) $ getImplicit3 <$> symbObjs
 
+getImplicit3 (DifferenceR3 _ symbObj []) =
+  getImplicit3 symbObj
 getImplicit3 (DifferenceR3 r symbObj symbObjs) =
     let
         tailObjs = getImplicit3 <$> symbObjs

--- a/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
@@ -50,6 +50,18 @@ getImplicit3 (Complement3 symbObj) =
     in
         \p -> - obj p
 getImplicit3 (UnionR3 _ []) = getImplicit3 Empty3
+-- TODO(sandy): This is non-associative somehow. Fix it.
+-- Test case:
+--   UnionR3 0 (obj : [ UnionR3 0 objs ]) =~=
+--     UnionR3 0 (obj : objs)
+--
+-- Result:
+--   Falsified (after 82 tests and 51 shrinks):
+--     Scale3 (2.0,3.0,5.0) (Sphere 34.21)
+--     [ExtrudeR 0.0 (Shell2 17.56485601360011 (UnionR2 2.0027171946836613 [Shell2 1.5984749452135119 (Scale2 (1.0898601265130337,-0.29055538926420654) (PolygonR 0.23223027098261984 [(0.0,0.0),(0.0,0.0),(0.0,0.0),(0.0,0.0),(0.0,0.0)
+--,  .0),(0.0,0.0),(0.0,0.0),(0.0,0.0),(0.0,0.0)]))])) 1.0,CubeR 0.0 (10.0,1.0,1.0)]
+--     ((0.0,0.0,0.0),())
+--     Inside /= Surface
 getImplicit3 (UnionR3 r symbObjs) =
   \p -> rminimum r $ fmap ($p) $ getImplicit3 <$> symbObjs
 

--- a/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
@@ -5,10 +5,10 @@
 
 module Graphics.Implicit.ObjectUtil.GetImplicit3 (getImplicit3) where
 
-import Prelude (Either(Left, Right), abs, (-), (/), (*), sqrt, (+), atan2, max, cos, fmap, minimum, ($), (**), sin, pi, (.), Bool(True, False), ceiling, floor, pure, error, (>), (&&), (<), (==), otherwise, (<$>))
+import Prelude (const, Fractional, Either(Left, Right), abs, (-), (/), (*), sqrt, (+), atan2, max, cos, fmap, minimum, ($), (**), sin, pi, (.), Bool(True, False), ceiling, floor, pure, error, (>), (&&), (<), (==), otherwise, (<$>))
 
 import Graphics.Implicit.Definitions (ℝ, ℕ, ℝ2, ℝ3, (⋯/), Obj3,
-                                      SymbolicObj3(Shell3, UnionR3, IntersectR3, DifferenceR3, Translate3, Scale3, Rotate3,
+                                      SymbolicObj3(Empty3, Full3, Shell3, UnionR3, IntersectR3, DifferenceR3, Translate3, Scale3, Rotate3,
                                                    Outset3, CubeR, Sphere, Cylinder, Complement3, EmbedBoxedObj3, Mirror3,
                                                    ExtrudeR, ExtrudeRM, ExtrudeOnEdgeOf, RotateExtrude, ExtrudeRotateR), fromℕtoℝ, toScaleFn, minℝ)
 
@@ -25,9 +25,14 @@ import Data.VectorSpace (AdditiveGroup((^-^)))
 
 default (ℝ)
 
+infty :: Fractional t => t
+infty = 1 / 0
+
 -- Get a function that describes the surface of the object.
 getImplicit3 :: SymbolicObj3 -> Obj3
 -- Primitives
+getImplicit3 Empty3 = const infty
+getImplicit3 Full3 = const $ -infty
 getImplicit3 (CubeR r (dx, dy, dz)) =
     \(x,y,z) -> rmaximum r [abs (x-dx/2) - dx/2, abs (y-dy/2) - dy/2, abs (z-dz/2) - dz/2]
 getImplicit3 (Sphere r) =
@@ -44,6 +49,7 @@ getImplicit3 (Complement3 symbObj) =
         obj = getImplicit3 symbObj
     in
         \p -> - obj p
+getImplicit3 (UnionR3 _ []) = getImplicit3 Empty3
 getImplicit3 (UnionR3 r symbObjs) =
   \p -> rminimum r $ fmap ($p) $ getImplicit3 <$> symbObjs
 

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -39,6 +39,7 @@ module Graphics.Implicit.Primitives (
                                      Object
                                     ) where
 
+import GHC.Generics
 import Prelude((*), (/), (.), mempty, negate, Bool(True, False), Maybe(Just, Nothing), Either, fmap, ($))
 
 import Graphics.Implicit.Definitions (both, allthree, ℝ, ℝ2, ℝ3, Box2,
@@ -59,6 +60,8 @@ import Graphics.Implicit.Definitions (both, allthree, ℝ, ℝ2, ℝ3, Box2,
                                                    EmbedBoxedObj2
                                                   ),
                                       SymbolicObj3(
+                                                   Empty3,
+                                                   Full3,
                                                    CubeR,
                                                    Sphere,
                                                    Cylinder,
@@ -259,19 +262,23 @@ instance Object SymbolicObj2 ℝ2 where
     implicit a b= EmbedBoxedObj2 (a,b)
 
 instance Object SymbolicObj3 ℝ3 where
-    translate   = Translate3
-    mirror      = Mirror3
-    scale       = Scale3
-    complement  = Complement3
-    unionR _ [] = mempty
-    unionR r ss = UnionR3 r ss
-    intersectR  = IntersectR3
-    differenceR = DifferenceR3
-    outset      = Outset3
-    shell       = Shell3
-    getBox      = getBox3
-    getImplicit = getImplicit3
-    implicit a b= EmbedBoxedObj3 (a,b)
+    translate _ Empty3         = Empty3
+    translate x s              = Translate3 x s
+    mirror _ Empty3            = Empty3
+    mirror x s                 = Mirror3 x s
+    scale _ Empty3             = Empty3
+    scale x s                  = Scale3 x s
+    complement (Complement3 s) = s
+    complement s               = Complement3 s
+    unionR _ []                = mempty
+    unionR r ss                = UnionR3 r ss
+    intersectR                 = IntersectR3
+    differenceR                = DifferenceR3
+    outset                     = Outset3
+    shell                      = Shell3
+    getBox                     = getBox3
+    getImplicit                = getImplicit3
+    implicit a b               = EmbedBoxedObj3 (a,b)
 
 union :: Object obj vec => [obj] -> obj
 union = unionR 0

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -36,6 +36,8 @@ module Graphics.Implicit.Primitives (
                                      rotate,
                                      pack2,
                                      implicit,
+                                     emptySpace,
+                                     fullSpace,
                                      Object
                                     ) where
 
@@ -176,6 +178,11 @@ polygonR = PolygonR
 --
 -- Library users shouldn't need to provide new instances of this class.
 class Object obj vec | obj -> vec where
+    -- | The object that fills no space
+    emptySpace :: obj
+
+    -- | The object that fills the entire space
+    fullSpace :: obj
 
     -- | Complement an Object
     complement ::
@@ -248,27 +255,29 @@ class Object obj vec | obj -> vec where
 
 
 instance Object SymbolicObj2 ℝ2 where
-    translate   = Translate2
-    mirror      = Mirror2
-    scale       = Scale2
-    complement  = Complement2
-    unionR _ [] = mempty
-    unionR r ss = UnionR2 r ss
-    intersectR  = IntersectR2
-    differenceR = DifferenceR2
-    outset      = Outset2
-    shell       = Shell2
-    getBox      = getBox2
-    getImplicit = getImplicit2
-    implicit a b= EmbedBoxedObj2 (a,b)
+    emptySpace                 = Empty2
+    fullSpace                  = Full2
+    translate                  = Translate2
+    mirror                     = Mirror2
+    scale                      = Scale2
+    complement (Complement2 s) = s
+    complement s               = Complement2 s
+    unionR _ []                = mempty
+    unionR r ss                = UnionR2 r ss
+    intersectR                 = IntersectR2
+    differenceR                = DifferenceR2
+    outset                     = Outset2
+    shell                      = Shell2
+    getBox                     = getBox2
+    getImplicit                = getImplicit2
+    implicit a b               = EmbedBoxedObj2 (a,b)
 
 instance Object SymbolicObj3 ℝ3 where
-    translate _ Empty3         = Empty3
-    translate x s              = Translate3 x s
-    mirror _ Empty3            = Empty3
-    mirror x s                 = Mirror3 x s
-    scale _ Empty3             = Empty3
-    scale x s                  = Scale3 x s
+    emptySpace                 = Empty3
+    fullSpace                  = Full3
+    translate                  = Translate3
+    mirror                     = Mirror3
+    scale                      = Scale3
     complement (Complement3 s) = s
     complement s               = Complement3 s
     unionR _ []                = mempty

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -39,11 +39,12 @@ module Graphics.Implicit.Primitives (
                                      Object
                                     ) where
 
-import GHC.Generics
 import Prelude((*), (/), (.), mempty, negate, Bool(True, False), Maybe(Just, Nothing), Either, fmap, ($))
 
 import Graphics.Implicit.Definitions (both, allthree, ℝ, ℝ2, ℝ3, Box2,
                                       SymbolicObj2(
+                                                   Empty2,
+                                                   Full2,
                                                    SquareR,
                                                    Circle,
                                                    PolygonR,

--- a/tests/Graphics/Implicit/Test/Instances.hs
+++ b/tests/Graphics/Implicit/Test/Instances.hs
@@ -4,9 +4,9 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Graphics.Implicit.Test.Instances (Quantizable (quantize), epsilon, observe, (=~=)) where
+module Graphics.Implicit.Test.Instances (epsilon, observe, (=~=)) where
 
-import Prelude (Bounded, Enum, Show, Ord, Eq, (==), pure, Bool (True, False), Int, Double, Integer, (.), flip, uncurry, ($), (>), (<), (&&), all, (>=), length, div, (<*>), (<$>), (+), fmap, (/), fromIntegral, (^), (*), (<>), round, (<=), filter, notElem)
+import Prelude (Bounded, Enum, Show, Ord, Eq, (==), pure, Bool (True, False), Int, Double, (.), flip, uncurry, ($), (>), (<), (&&), all, (>=), length, div, (<*>), (<$>), (+), (<>), (<=), filter, notElem)
 
 import Data.VectorSpace (magnitudeSq, AdditiveGroup((^-^)))
 
@@ -38,9 +38,7 @@ import Graphics.Implicit.Definitions
                    Shell3, CubeR),
       SymbolicObj2(SquareR, Complement2, UnionR2, DifferenceR2,
                    IntersectR2, Translate2, Scale2, Rotate2, Outset2, Shell2,
-                   PolygonR),
-      both,
-      allthree )
+                   PolygonR) )
 
 import Graphics.Implicit.Primitives ( Object(getBox, getImplicit) )
 
@@ -145,32 +143,6 @@ instance Observe (ℝ2, ()) Insidedness SymbolicObj2 where
 instance Observe (ℝ3, ()) Insidedness SymbolicObj3 where
   observe p = insidedness . observe p . getImplicit
 
-
-------------------------------------------------------------------------------
--- | Types which can truncate their decimal points to a certain number of
--- digits.
-class Quantizable a where
-  quantize
-      :: Int  -- ^ The number of decimal points to keep
-      -> a
-      -> a
-
-instance Quantizable a => Quantizable [a] where
-  quantize n = fmap (quantize n)
-
-instance Quantizable a => Quantizable (a, a) where
-  quantize n = both (quantize n)
-
-instance Quantizable a => Quantizable (a, a, a) where
-  quantize n = allthree (quantize n)
-
-instance Quantizable a => Quantizable (b -> a) where
-  quantize n = fmap (quantize n)
-
-instance Quantizable Double where
-  quantize n r =
-    let pow = 10 ^ n :: Double
-    in fromIntegral @Integer (round (r * pow)) / pow
 
 
 ------------------------------------------------------------------------------

--- a/tests/Graphics/Implicit/Test/Instances.hs
+++ b/tests/Graphics/Implicit/Test/Instances.hs
@@ -215,7 +215,7 @@ isValid2 s@(PolygonR _ ls) = length ls >= 3 &&
 isValid2 (SquareR _ (x0, y0)) = (0 < x0) && (0 < y0)
 isValid2 s =  -- Otherwise, make sure it has > 0 volume
   let (dx, dy) = boxSize s
-   in notElem 0 [dx, dy]
+   in all (> 0) [dx, dy]
 
 -- | Determine if a 'SymbolicObj3' is well-constructed. Ensures we don't
 -- accidentally generate a term which will crash when we attempt to render it.
@@ -235,7 +235,7 @@ isValid3 (CubeR _ (x0, y0, z0)) = (0 < x0) && (0 < y0) && (0 < z0)
 isValid3 (Cylinder _ r h) = r > 0 && h > 0
 isValid3 s =  -- Otherwise, make sure it has > 0 volume
   let (dx, dy, dz) = boxSize s
-   in notElem 0 [dx, dy, dz]
+   in all (> 0) [dx, dy, dz]
 
 
 ------------------------------------------------------------------------------

--- a/tests/Graphics/Implicit/Test/Instances.hs
+++ b/tests/Graphics/Implicit/Test/Instances.hs
@@ -6,7 +6,7 @@
 
 module Graphics.Implicit.Test.Instances (epsilon, observe, (=~=)) where
 
-import Prelude (Bounded, Enum, Show, Ord, Eq, (/=), (==), pure, Bool (True, False), Int, Double, (.), flip, uncurry, ($), (>), (<), (&&), all, (>=), length, div, (<*>), (<$>), (+), (<>), (<=), filter, notElem)
+import Prelude (Bounded, Enum, Show, Ord, Eq, (==), pure, Bool (True, False), Int, Double, (.), flip, uncurry, ($), (>), (<), (&&), all, (>=), length, div, (<*>), (<$>), (+), (<>), (<=), filter, notElem)
 
 import Data.VectorSpace (magnitudeSq, AdditiveGroup((^-^)))
 
@@ -58,6 +58,7 @@ import Test.QuickCheck
 import Data.List (nub)
 import Linear (Quaternion, axisAngle)
 import Graphics.Implicit.MathUtil (packV3)
+import Data.Bool (bool)
 
 
 data Insidedness = Inside | Outside | Surface
@@ -90,7 +91,10 @@ instance Arbitrary SymbolicObj2 where
       small =
         [ circle   <$> arbitrary
         , squareR  <$> arbitraryPos <*> arbitrary <*> arbitrary
-        , polygonR <$> arbitraryPos <*> decayedList
+        , polygonR <$> arbitraryPos <*> do
+            n <- choose (5, 10)
+            v <- nub <$> vectorOf n arbitrary
+            pure $ bool discard v $ length v >= 3
         , pure fullSpace
         , pure emptySpace
         ]
@@ -200,7 +204,7 @@ isValid2 (Scale2 (x, y) s) = x > 0 && y > 0 && isValid2 s
 isValid2 (Rotate2 _ s) = isValid2 s
 isValid2 (Outset2 _ s) = isValid2 s
 isValid2 (Shell2 _ s) = isValid2 s
-isValid2 s@(PolygonR _ ls) = length ls >= 3 && nub ls /= ls &&
+isValid2 s@(PolygonR _ ls) = length ls >= 3 && nub ls == ls &&
   let (dx, dy) = boxSize s
    in notElem 0 [dx, dy]
 isValid2 (SquareR _ (x0, y0)) = (0 < x0) && (0 < y0)

--- a/tests/Graphics/Implicit/Test/Instances.hs
+++ b/tests/Graphics/Implicit/Test/Instances.hs
@@ -6,7 +6,7 @@
 
 module Graphics.Implicit.Test.Instances (epsilon, observe, (=~=)) where
 
-import Prelude (Bounded, Enum, Show, Ord, Eq, (==), pure, Bool (True, False), Int, Double, (.), flip, uncurry, ($), (>), (<), (&&), all, (>=), length, div, (<*>), (<$>), (+), (<>), (<=), filter, notElem)
+import Prelude (Bounded, Enum, Show, Ord, Eq, (/=), (==), pure, Bool (True, False), Int, Double, (.), flip, uncurry, ($), (>), (<), (&&), all, (>=), length, div, (<*>), (<$>), (+), (<>), (<=), filter, notElem)
 
 import Data.VectorSpace (magnitudeSq, AdditiveGroup((^-^)))
 
@@ -55,6 +55,7 @@ import Test.QuickCheck
       Gen,
       Positive(getPositive) )
 
+import Data.List (nub)
 import Linear (Quaternion, axisAngle)
 import Graphics.Implicit.MathUtil (packV3)
 
@@ -199,7 +200,7 @@ isValid2 (Scale2 (x, y) s) = x > 0 && y > 0 && isValid2 s
 isValid2 (Rotate2 _ s) = isValid2 s
 isValid2 (Outset2 _ s) = isValid2 s
 isValid2 (Shell2 _ s) = isValid2 s
-isValid2 s@(PolygonR _ ls) = length ls >= 3 &&
+isValid2 s@(PolygonR _ ls) = length ls >= 3 && nub ls /= ls &&
   let (dx, dy) = boxSize s
    in notElem 0 [dx, dy]
 isValid2 (SquareR _ (x0, y0)) = (0 < x0) && (0 < y0)

--- a/tests/Graphics/Implicit/Test/Instances.hs
+++ b/tests/Graphics/Implicit/Test/Instances.hs
@@ -20,7 +20,7 @@ import Graphics.Implicit
       ℝ2,
       ℝ,
       squareR,
-      Object(shell, translate, unionR, intersectR, differenceR),
+      Object(shell, translate, unionR, intersectR, differenceR, emptySpace, fullSpace),
       sphere,
       cubeR,
       cylinder2,
@@ -90,6 +90,8 @@ instance Arbitrary SymbolicObj2 where
         [ circle   <$> arbitrary
         , squareR  <$> arbitraryPos <*> arbitrary <*> arbitrary
         , polygonR <$> arbitraryPos <*> decayedList
+        , pure fullSpace
+        , pure emptySpace
         ]
 
 
@@ -110,6 +112,8 @@ instance Arbitrary SymbolicObj3 where
         , cylinder  <$> arbitraryPos <*> arbitraryPos
         , cylinder2 <$> arbitraryPos <*> arbitraryPos <*> arbitraryPos
         , cubeR     <$> arbitraryPos <*> arbitrary    <*> arbitraryV3
+        , pure fullSpace
+        , pure emptySpace
         ]
 
 instance Arbitrary ExtrudeRMScale where

--- a/tests/Graphics/Implicit/Test/Instances.hs
+++ b/tests/Graphics/Implicit/Test/Instances.hs
@@ -33,10 +33,10 @@ import Graphics.Implicit
       rotate )
 
 import Graphics.Implicit.Definitions
-    ( SymbolicObj3(Cylinder, Complement3, UnionR3, DifferenceR3,
+    ( SymbolicObj3(Full3, Empty3, Cylinder, Complement3, UnionR3, DifferenceR3,
                    IntersectR3, Translate3, Scale3, Rotate3, Outset3,
                    Shell3, CubeR),
-      SymbolicObj2(SquareR, Complement2, UnionR2, DifferenceR2,
+      SymbolicObj2(Full2, Empty2, SquareR, Complement2, UnionR2, DifferenceR2,
                    IntersectR2, Translate2, Scale2, Rotate2, Outset2, Shell2,
                    PolygonR) )
 
@@ -182,6 +182,8 @@ decayArbitrary n = scale (`div` n) arbitrary
 -- | Determine if a 'SymbolicObj2' is well-constructed. Ensures we don't
 -- accidentally generate a term which will crash when we attempt to render it.
 isValid2 :: SymbolicObj2 -> Bool
+isValid2 Empty2 = True
+isValid2 Full2 = True
 isValid2 (Complement2 s) = isValid2 s
 isValid2 (UnionR2 _ []) = False  -- Bug #304
 isValid2 (UnionR2 _ l_s) = all isValid2 l_s
@@ -204,6 +206,8 @@ isValid2 s =  -- Otherwise, make sure it has > 0 volume
 -- | Determine if a 'SymbolicObj3' is well-constructed. Ensures we don't
 -- accidentally generate a term which will crash when we attempt to render it.
 isValid3 :: SymbolicObj3 -> Bool
+isValid3 Empty3 = True
+isValid3 Full3 = True
 isValid3 (Complement3 s) = isValid3 s
 isValid3 (UnionR3 _ []) = False  -- Bug #304
 isValid3 (UnionR3 _ l_s) = all isValid3 l_s

--- a/tests/ImplicitSpec.hs
+++ b/tests/ImplicitSpec.hs
@@ -5,15 +5,15 @@
 
 module ImplicitSpec (spec) where
 
-import Prelude (Num, Show, Monoid, mempty, (*), (<>), (-), (/=), ($), (.), pi, id)
-import Test.Hspec (describe, Spec)
+import Prelude (String, Num, Show, Monoid, mempty, (*), (<>), (-), (/=), ($), (.), pi, id)
+import Test.Hspec (SpecWith, it, describe, Spec)
 import Graphics.Implicit.Test.Instances ((=~=))
 import Graphics.Implicit
 import Graphics.Implicit.Primitives (rotateQ)
 import Test.QuickCheck
-    ( Arbitrary(arbitrary),
+    (Testable, property, expectFailure,  Arbitrary(arbitrary),
       suchThat,
-      forAll )
+      forAll)
 import Data.Foldable ( for_ )
 import Data.VectorSpace (AdditiveGroup, (^+^),  (^*) )
 import Test.Hspec.QuickCheck (prop)
@@ -144,6 +144,10 @@ identitySpec = describe "identity" $ do
     differenceR r Empty3 objs
       =~= Empty3
 
+  failingProp "difference is complement" $ \objs ->
+    difference Full3 objs
+      =~= complement (union objs)
+
   prop "difference of obj" $ \r obj ->
     differenceR @SymbolicObj3 r obj []
       =~= obj
@@ -168,4 +172,8 @@ homomorphismSpec = describe "homomorphism" $ do
   prop "rotate" $ \q1 q2 ->
     rotateQ q2 . rotateQ q1
       =~= rotateQ (q2 * q1)
+
+
+failingProp :: Testable prop => String -> prop -> SpecWith ()
+failingProp x = it x . expectFailure . property
 

--- a/tests/ImplicitSpec.hs
+++ b/tests/ImplicitSpec.hs
@@ -24,18 +24,18 @@ import QuickSpec (Observe)
 spec :: Spec
 spec = do
   describe "symbolic obj 2" $ do
-    idempotenceSpec @SymbolicObj2
-    identitySpec @SymbolicObj2
+    idempotenceSpec  @SymbolicObj2
+    identitySpec     @SymbolicObj2
     homomorphismSpec @SymbolicObj2
-    monoidSpec @SymbolicObj2
-    inverseSpec @SymbolicObj2
+    monoidSpec       @SymbolicObj2
+    inverseSpec      @SymbolicObj2
     annihilationSpec @SymbolicObj2
   describe "symbolic obj 3" $ do
-    idempotenceSpec @SymbolicObj3
-    identitySpec @SymbolicObj3
+    idempotenceSpec  @SymbolicObj3
+    identitySpec     @SymbolicObj3
     homomorphismSpec @SymbolicObj3
-    monoidSpec @SymbolicObj3
-    inverseSpec @SymbolicObj3
+    monoidSpec       @SymbolicObj3
+    inverseSpec      @SymbolicObj3
     annihilationSpec @SymbolicObj3
 
 

--- a/tests/ImplicitSpec.hs
+++ b/tests/ImplicitSpec.hs
@@ -28,7 +28,6 @@ import Test.QuickCheck
 import Data.Foldable ( for_ )
 import Data.VectorSpace (AdditiveGroup, (^+^),  (^*) )
 import Test.Hspec.QuickCheck (prop)
-import Graphics.Implicit.Definitions ()
 import QuickSpec (Observe)
 import Data.Typeable ( Typeable, type (:~:)(Refl), eqT )
 

--- a/tests/ImplicitSpec.hs
+++ b/tests/ImplicitSpec.hs
@@ -23,13 +23,16 @@ import QuickSpec (Observe)
 
 spec :: Spec
 spec = do
-  idempotenceSpec
-  identitySpec
   describe "symbolic obj 2" $ do
+    idempotenceSpec @SymbolicObj2
+    identitySpec @SymbolicObj2
     homomorphismSpec @SymbolicObj2
     monoidSpec @SymbolicObj2
     inverseSpec @SymbolicObj2
+    annihilationSpec @SymbolicObj2
   describe "symbolic obj 3" $ do
+    idempotenceSpec @SymbolicObj3
+    identitySpec @SymbolicObj3
     homomorphismSpec @SymbolicObj3
     monoidSpec @SymbolicObj3
     inverseSpec @SymbolicObj3
@@ -65,20 +68,23 @@ monoidSpec = describe "monoid" $ do
     union @obj [obj] =~= obj
 
 
-idempotenceSpec :: Spec
+idempotenceSpec
+    :: forall obj vec test outcome
+     . TestInfrastructure obj vec test outcome
+    => Spec
 idempotenceSpec = describe "idempotence" $ do
-  for_ [("empty", Empty3), ("full", Full3)] $ \(name, obj) ->
+  for_ [("empty", emptySpace @obj), ("full", fullSpace)] $ \(name, obj) ->
     describe name $ do
       prop "idepotent wrt translate" $ \xyz ->
         translate xyz obj
           =~= obj
-      prop "idepotent wrt rotate" $ \xyz ->
-        rotate3 xyz obj
-          =~= obj
+      -- prop "idepotent wrt rotate" $ \xyz ->
+      --   rotate3 xyz obj
+      --     =~= obj
 
   prop "empty idepotent wrt scale" $ \xyz ->
-    scale xyz Empty3
-      =~= Empty3
+    scale xyz emptySpace
+      =~= emptySpace @obj
 
 
 inverseSpec
@@ -96,14 +102,17 @@ annihilationSpec
     => Spec
 annihilationSpec = describe "annihilation" $ do
   prop "union/full" $ \obj ->
-    Full3 <> obj
-      =~= Full3
+    fullSpace <> obj
+      =~= fullSpace @obj
   prop "union/full" $ \obj ->
-    obj <> Full3
-      =~= Full3
+    obj <> fullSpace
+      =~= fullSpace @obj
 
 
-identitySpec :: Spec
+identitySpec
+    :: forall obj vec test outcome
+     . TestInfrastructure obj vec test outcome
+    => Spec
 identitySpec = describe "identity" $ do
   describe "getImplicit" $ do
     for_ [ ("YZ", (1, 0, 0))
@@ -129,27 +138,27 @@ identitySpec = describe "identity" $ do
           =~= id
 
   prop "complement inverse" $
-    complement @SymbolicObj3 . complement
+    complement @obj . complement
       =~= id
 
   prop "complement empty" $
-    complement Empty3
-      =~= Full3
+    complement @obj emptySpace
+      =~= fullSpace
 
   prop "complement full" $
-    complement Full3
-      =~= Empty3
+    complement @obj fullSpace
+      =~= emptySpace
 
   prop "difference of empty" $ \r objs ->
-    differenceR r Empty3 objs
-      =~= Empty3
+    differenceR @obj r emptySpace objs
+      =~= emptySpace
 
   failingProp "difference is complement" $ \objs ->
-    difference Full3 objs
+    difference @obj fullSpace objs
       =~= complement (union objs)
 
   prop "difference of obj" $ \r obj ->
-    differenceR @SymbolicObj3 r obj []
+    differenceR @obj r obj []
       =~= obj
 
 

--- a/tests/ImplicitSpec.hs
+++ b/tests/ImplicitSpec.hs
@@ -33,6 +33,7 @@ spec = do
     homomorphismSpec @SymbolicObj3
     monoidSpec @SymbolicObj3
     inverseSpec @SymbolicObj3
+    annihilationSpec @SymbolicObj3
 
 
 type TestInfrastructure obj vec test outcome =
@@ -88,6 +89,18 @@ inverseSpec = describe "inverses" $ do
   prop "complement inverse" $
     complement @obj . complement
       =~= id
+
+annihilationSpec
+    :: forall obj vec test outcome
+     . TestInfrastructure obj vec test outcome
+    => Spec
+annihilationSpec = describe "annihilation" $ do
+  prop "union/full" $ \obj ->
+    Full3 <> obj
+      =~= Full3
+  prop "union/full" $ \obj ->
+    obj <> Full3
+      =~= Full3
 
 
 identitySpec :: Spec

--- a/tests/ImplicitSpec.hs
+++ b/tests/ImplicitSpec.hs
@@ -102,11 +102,11 @@ idempotenceSpec
 idempotenceSpec = describe "idempotence" $ do
   for_ [("empty", emptySpace @obj), ("full", fullSpace)] $ \(name, obj) ->
     describe name $ do
-      prop "idepotent wrt translate" $ \xyz ->
+      prop "idempotent wrt translate" $ \xyz ->
         translate xyz obj
           =~= obj
 
-  prop "empty idepotent wrt scale" $ \xyz ->
+  prop "empty idempotent wrt scale" $ \xyz ->
     scale xyz emptySpace
       =~= emptySpace @obj
 
@@ -168,11 +168,11 @@ rotation2dSpec = describe "2d rotation" $ do
     rotate rads2 . rotate rads2
       =~= rotate (rads1 + rads2)
 
-  prop "full idepotent wrt rotate" $ \rads ->
+  prop "full idempotent wrt rotate" $ \rads ->
     rotate rads fullSpace
       =~= fullSpace
 
-  prop "empty idepotent wrt rotate" $ \rads ->
+  prop "empty idempotent wrt rotate" $ \rads ->
     rotate rads emptySpace
       =~= emptySpace
 
@@ -206,11 +206,11 @@ rotation3dSpec = describe "3d rotation" $ do
     rotateQ q2 . rotateQ q1
       =~= rotateQ (q2 * q1)
 
-  prop "full idepotent wrt rotate" $ \xyz ->
+  prop "full idempotent wrt rotate" $ \xyz ->
     rotate3 xyz fullSpace
       =~= fullSpace
 
-  prop "empty idepotent wrt rotate" $ \xyz ->
+  prop "empty idempotent wrt rotate" $ \xyz ->
     rotate3 xyz emptySpace
       =~= emptySpace
 

--- a/tests/ImplicitSpec.hs
+++ b/tests/ImplicitSpec.hs
@@ -127,6 +127,14 @@ identitySpec = describe "identity" $ do
     complement Full3
       =~= Empty3
 
+  prop "difference of empty" $ \r objs ->
+    differenceR r Empty3 objs
+      =~= Empty3
+
+  prop "difference of obj" $ \r obj ->
+    differenceR @SymbolicObj3 r obj []
+      =~= obj
+
 
 homomorphismSpec
     :: forall obj vec test outcome
@@ -139,9 +147,11 @@ homomorphismSpec = describe "homomorphism" $ do
   prop "translate" $ \xyz1 xyz2 ->
     translate @obj xyz2 . translate xyz1
       =~= translate (xyz1 ^+^ xyz2)
+
   prop "scale" $ \xyz1 xyz2 ->
     scale @obj xyz2 . scale xyz1
       =~= scale (xyz1 * xyz2)
+
   prop "rotate" $ \q1 q2 ->
     rotateQ q2 . rotateQ q1
       =~= rotateQ (q2 * q1)


### PR DESCRIPTION
This PR:

1. Primarily, fixes #323, via:
2. Adding two new primitives to `Object`: `emptySpace` and `fullSpace`. The former acts as a proper unit for union, and the latter is its corresponding dual (and also annihilator for union)
3. Enforces associativity of the `(<>)` operation by fiat. The underlying bug in `union` is still present, but `(<>)` correctly reassociates everything so it Just Works
4. Adds tests to prove that the monoid instances are lawful
5. Adds thousands(!) of other tests, proving tons of algebraic properties about symbolic objects.