### PR TITLE
Add Actions based CI

### DIFF
--- a/.github/workflows/implicit.yaml
+++ b/.github/workflows/implicit.yaml
@@ -1,0 +1,36 @@
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: "actions/checkout@v1"
+      - id: setup-haskell-cabal
+        uses: "actions/setup-haskell@v1.1.4"
+        with:
+          cabal-version: "${{ matrix.cabal }}"
+          enable-stack: false
+          ghc-version: "${{ matrix.ghc }}"
+      - uses: "actions/cache@v1"
+        with:
+          key: "${{ runner.os }}-${{ matrix.ghc }}-cabal"
+          path: "${{ steps.setup-haskell-cabal.outputs.cabal-store }}"
+      - name: Install dependencies
+        run: |
+          cabal update
+          cabal build --enable-tests --enable-benchmarks --only-dependencies
+      - name: build
+        run: cabal build --enable-tests --enable-benchmarks
+      - name: test
+        run: cabal test --enable-tests
+      - name: haddock
+        run: cabal haddock 
+    strategy:
+      matrix:
+        cabal:
+          - '3.2'
+        ghc:
+          - '8.10.1'
+          - '8.8.3'
+          - '8.6.5'
+name: Haskell CI
+on:
+  - push

--- a/ci.dhall
+++ b/ci.dhall
@@ -1,0 +1,14 @@
+let haskellCi = https://raw.githubusercontent.com/vmchale/github-actions-dhall/master/haskell-ci.dhall
+
+in    haskellCi.generalCi
+        haskellCi.matrixSteps
+        ( Some
+            { ghc =
+              [ haskellCi.GHC.GHC8101
+              , haskellCi.GHC.GHC883
+              , haskellCi.GHC.GHC865
+              ]
+            , cabal = [ haskellCi.Cabal.Cabal32 ]
+            }
+        )
+    : haskellCi.CI.Type


### PR DESCRIPTION
Uses https://github.com/vmchale/github-actions-dhall

Yaml can be regenerated with

```
dhall-to-yaml --file ci.dhall > .github/workflows/implicit.yaml
```

There are two changes done by hand unless these two are resolved:
https://github.com/vmchale/github-actions-dhall/pull/3
https://github.com/vmchale/github-actions-dhall/pull/4
