### PR TITLE
2d shape fixes

### DIFF
--- a/Graphics/Implicit/MathUtil.hs
+++ b/Graphics/Implicit/MathUtil.hs
@@ -200,4 +200,5 @@ unpackV3 (V3 a a2 a3) = (a, a2, a3)
 -- in any convenient way, so we define it here.
 infty :: (Fractional t) => t
 infty = 1/0
+{-# INLINABLE infty #-}
 

--- a/Graphics/Implicit/ObjectUtil/GetImplicit2.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit2.hs
@@ -1,17 +1,35 @@
+{-# LANGUAGE ViewPatterns #-}
 -- Implicit CAD. Copyright (C) 2011, Christopher Olah (chris@colah.ca)
 -- Copyright (C) 2016, Julia Longtin (julial@turinglace.com)
 -- Released under the GNU AGPLV3+, see LICENSE
 
 module Graphics.Implicit.ObjectUtil.GetImplicit2 (getImplicit2) where
 
-import Prelude((<$>), const, abs, (-), (/), sqrt, (*), (+), mod, length, fmap, (<=), (&&), (>=), (||), odd, ($), (>), filter, (<), minimum, max, cos, sin, tail, (.))
+import Prelude((/=), uncurry, fst, Eq, zip, drop, (<>), (<$>), const, abs, (-), (/), sqrt, (*), (+), length, fmap, (<=), (&&), (>=), (||), odd, ($), (>), filter, (<), minimum, max, cos, sin, (.))
 
-import Graphics.Implicit.Definitions (minℝ, ℝ, ℕ, ℝ2, (⋯/), Obj2, SymbolicObj2(Empty2, Full2, SquareR, Circle, PolygonR, Complement2, UnionR2, DifferenceR2, IntersectR2, Translate2, Scale2, Rotate2, Mirror2, Shell2, Outset2, EmbedBoxedObj2))
+import Graphics.Implicit.Definitions (minℝ, ℝ, ℝ2, (⋯/), Obj2, SymbolicObj2(Empty2, Full2, SquareR, Circle, PolygonR, Complement2, UnionR2, DifferenceR2, IntersectR2, Translate2, Scale2, Rotate2, Mirror2, Shell2, Outset2, EmbedBoxedObj2))
 
 import Graphics.Implicit.MathUtil (rmax, infty, reflect, rminimum, rmaximum, distFromLineSeg)
 
 import Data.VectorSpace ((^-^))
-import Data.List (nub, genericIndex, genericLength)
+import Data.List (nub)
+
+
+------------------------------------------------------------------------------
+-- | Filter out equal consecutive elements in the list. This function will
+-- additionally trim the last  element of the lst if it's equal to the first.
+scanUniqueCircular :: Eq a => [a] -> [a]
+scanUniqueCircular
+    = fmap fst
+    . filter (uncurry (/=))
+    . circularPairs
+
+
+------------------------------------------------------------------------------
+-- | Given @[a, b, c, ... n]@, return the pairs @[(a, b), (b, c), ... (n, a)]@.
+circularPairs :: [a] -> [(a,a)]
+circularPairs as = zip as (drop 1 as <> as)
+
 
 getImplicit2 :: SymbolicObj2 -> Obj2
 -- Primitives
@@ -24,12 +42,10 @@ getImplicit2 (SquareR r (dx, dy)) =
 getImplicit2 (Circle r) =
     \(x,y) -> sqrt (x * x + y * y) - r
 -- FIXME: stop ignoring rounding for polygons.
-getImplicit2 (PolygonR _ points) =
+getImplicit2 (PolygonR _ (scanUniqueCircular -> points@(_:_:_:_))) =
     \p -> let
-        pair :: ℕ -> (ℝ2,ℝ2)
-        pair n = (points `genericIndex` n, points `genericIndex` mod (n + 1) (genericLength points) )
         pairs :: [(ℝ2,ℝ2)]
-        pairs =  [ pair n | n <- [0 .. genericLength points - 1] ]
+        pairs =  circularPairs points
         relativePairs =  fmap (\(a,b) -> (a ^-^ p, b ^-^ p) ) pairs
         crossing_points =
             [x2 ^-^ y2*(x2-x1)/(y2-y1) | ((x1,y1), (x2,y2)) <-relativePairs,
@@ -42,6 +58,7 @@ getImplicit2 (PolygonR _ points) =
         dists = fmap (distFromLineSeg p) pairs
     in
         minimum dists * if isIn then -1 else 1
+getImplicit2 (PolygonR _ _) = getImplicit2 Empty2
 -- (Rounded) CSG
 getImplicit2 (Complement2 symbObj) =
     \p -> let

--- a/Graphics/Implicit/ObjectUtil/GetImplicit2.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit2.hs
@@ -5,7 +5,7 @@
 
 module Graphics.Implicit.ObjectUtil.GetImplicit2 (getImplicit2) where
 
-import Prelude((/=), uncurry, fst, Eq, zip, drop, (<>), (<$>), const, abs, (-), (/), sqrt, (*), (+), length, fmap, (<=), (&&), (>=), (||), odd, ($), (>), filter, (<), minimum, max, cos, sin, (.))
+import Prelude(cycle, (/=), uncurry, fst, Eq, zip, drop, (<$>), const, abs, (-), (/), sqrt, (*), (+), length, fmap, (<=), (&&), (>=), (||), odd, ($), (>), filter, (<), minimum, max, cos, sin, (.))
 
 import Graphics.Implicit.Definitions (minℝ, ℝ, ℝ2, (⋯/), Obj2, SymbolicObj2(Empty2, Full2, SquareR, Circle, PolygonR, Complement2, UnionR2, DifferenceR2, IntersectR2, Translate2, Scale2, Rotate2, Mirror2, Shell2, Outset2, EmbedBoxedObj2))
 
@@ -28,7 +28,7 @@ scanUniqueCircular
 ------------------------------------------------------------------------------
 -- | Given @[a, b, c, ... n]@, return the pairs @[(a, b), (b, c), ... (n, a)]@.
 circularPairs :: [a] -> [(a,a)]
-circularPairs as = zip as (drop 1 as <> as)
+circularPairs as = zip as $ drop 1 $ cycle as
 
 
 getImplicit2 :: SymbolicObj2 -> Obj2

--- a/Graphics/Implicit/ObjectUtil/GetImplicit2.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit2.hs
@@ -65,6 +65,7 @@ getImplicit2 (Complement2 symbObj) =
         obj = getImplicit2 symbObj
     in
         - obj p
+getImplicit2 (UnionR2 _ []) = getImplicit2 Empty2
 getImplicit2 (UnionR2 r symbObjs) =
     \p -> let
         objs = fmap getImplicit2 symbObjs

--- a/Graphics/Implicit/ObjectUtil/GetImplicit2.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit2.hs
@@ -17,7 +17,7 @@ import Data.List (nub)
 
 ------------------------------------------------------------------------------
 -- | Filter out equal consecutive elements in the list. This function will
--- additionally trim the last  element of the lst if it's equal to the first.
+-- additionally trim the last element of the list if it's equal to the first.
 scanUniqueCircular :: Eq a => [a] -> [a]
 scanUniqueCircular
     = fmap fst
@@ -122,4 +122,3 @@ getImplicit2 (Outset2 d symbObj) =
         obj p - d
 -- Misc
 getImplicit2 (EmbedBoxedObj2 (obj,_)) = obj
-

--- a/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
@@ -47,18 +47,6 @@ getImplicit3 (Complement3 symbObj) =
     in
         \p -> - obj p
 getImplicit3 (UnionR3 _ []) = getImplicit3 Empty3
--- TODO(sandy): This is non-associative somehow. Fix it.
--- Test case:
---   UnionR3 0 (obj : [ UnionR3 0 objs ]) =~=
---     UnionR3 0 (obj : objs)
---
--- Result:
---   Falsified (after 82 tests and 51 shrinks):
---     Scale3 (2.0,3.0,5.0) (Sphere 34.21)
---     [ExtrudeR 0.0 (Shell2 17.56485601360011 (UnionR2 2.0027171946836613 [Shell2 1.5984749452135119 (Scale2 (1.0898601265130337,-0.29055538926420654) (PolygonR 0.23223027098261984 [(0.0,0.0),(0.0,0.0),(0.0,0.0),(0.0,0.0),(0.0,0.0)
---,  .0),(0.0,0.0),(0.0,0.0),(0.0,0.0),(0.0,0.0)]))])) 1.0,CubeR 0.0 (10.0,1.0,1.0)]
---     ((0.0,0.0,0.0),())
---     Inside /= Surface
 getImplicit3 (UnionR3 r symbObjs) =
   \p -> rminimum r $ fmap ($p) $ getImplicit3 <$> symbObjs
 

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -262,8 +262,7 @@ instance Object SymbolicObj2 ℝ2 where
     scale                      = Scale2
     complement (Complement2 s) = s
     complement s               = Complement2 s
-    unionR _ []                = mempty
-    unionR r ss                = UnionR2 r ss
+    unionR                     = UnionR2
     intersectR                 = IntersectR2
     differenceR                = DifferenceR2
     outset                     = Outset2
@@ -280,8 +279,7 @@ instance Object SymbolicObj3 ℝ3 where
     scale                      = Scale3
     complement (Complement3 s) = s
     complement s               = Complement3 s
-    unionR _ []                = mempty
-    unionR r ss                = UnionR3 r ss
+    unionR                     = UnionR3
     intersectR                 = IntersectR3
     differenceR                = DifferenceR3
     outset                     = Outset3

--- a/tests/Graphics/Implicit/Test/Instances.hs
+++ b/tests/Graphics/Implicit/Test/Instances.hs
@@ -4,7 +4,7 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Graphics.Implicit.Test.Instances (epsilon, observe, (=~=)) where
+module Graphics.Implicit.Test.Instances (observe, (=~=)) where
 
 import Prelude (Bounded, Enum, Show, Ord, Eq, (==), pure, Bool (True, False), Int, Double, (.), flip, uncurry, ($), (>), (<), (&&), all, (>=), length, div, (<*>), (<$>), (+), (<>), (<=), filter, notElem)
 
@@ -71,12 +71,6 @@ insidedness x =
   case x < 0 of
     True  -> Inside
     False -> Outside
-
-------------------------------------------------------------------------------
--- | The number of decimal points we need to agree to assume two 'Double's are
--- equal.
-epsilon :: Int
-epsilon = 5
 
 ------------------------------------------------------------------------------
 instance Arbitrary SymbolicObj2 where

--- a/tests/Graphics/Implicit/Test/Instances.hs
+++ b/tests/Graphics/Implicit/Test/Instances.hs
@@ -58,7 +58,6 @@ import Test.QuickCheck
 import Data.List (nub)
 import Linear (Quaternion, axisAngle)
 import Graphics.Implicit.MathUtil (packV3)
-import Data.Bool (bool)
 
 
 data Insidedness = Inside | Outside | Surface
@@ -86,9 +85,8 @@ instance Arbitrary SymbolicObj2 where
         [ circle   <$> arbitrary
         , squareR  <$> arbitraryPos <*> arbitrary <*> arbitrary
         , polygonR <$> arbitraryPos <*> do
-            n <- choose (5, 10)
-            v <- nub <$> vectorOf n arbitrary
-            pure $ bool discard v $ length v >= 3
+            n <- choose (3, 10)
+            vectorOf n arbitrary
         , pure fullSpace
         , pure emptySpace
         ]

--- a/tests/ImplicitSpec.hs
+++ b/tests/ImplicitSpec.hs
@@ -7,7 +7,7 @@
 
 module ImplicitSpec (spec) where
 
-import Prelude (pure, Maybe (Just, Nothing), negate, (+), String, Num, Show, Monoid, mempty, (*), (<>), (-), (/=), ($), (.), pi, id)
+import Prelude (negate, (+), String, Num, Show, Monoid, mempty, (*), (<>), (-), (/=), ($), (.), pi, id)
 import Test.Hspec (SpecWith, it, describe, Spec)
 import Graphics.Implicit.Test.Instances ((=~=))
 import Graphics.Implicit
@@ -29,7 +29,6 @@ import Data.Foldable ( for_ )
 import Data.VectorSpace (AdditiveGroup, (^+^),  (^*) )
 import Test.Hspec.QuickCheck (prop)
 import QuickSpec (Observe)
-import Data.Typeable ( Typeable, type (:~:)(Refl), eqT )
 
 
 ------------------------------------------------------------------------------
@@ -218,9 +217,7 @@ rotation3dSpec = describe "3d rotation" $ do
 -- | Misc identity proofs that should hold for all symbolic objects.
 identitySpec
     :: forall obj vec test outcome
-     . ( TestInfrastructure obj vec test outcome
-       , Typeable obj
-       )
+     . TestInfrastructure obj vec test outcome
     => Spec
 identitySpec = describe "identity" $ do
   prop "complement empty" $
@@ -235,13 +232,9 @@ identitySpec = describe "identity" $ do
     differenceR @obj r emptySpace objs
       =~= emptySpace
 
-  case eqT @obj @SymbolicObj3 of
-    -- This test is broken in 2d due to #328, so only run it if we're in 3d.
-    Just Refl ->
-      prop "difference is complement" $ \objs ->
-        difference @obj fullSpace objs
-          =~= complement (union objs)
-    Nothing -> pure ()
+  prop "difference is complement" $ \objs ->
+    difference @obj fullSpace objs
+      =~= complement (union objs)
 
   prop "difference of obj" $ \r obj ->
     differenceR @obj r obj []


### PR DESCRIPTION
This PR:

* ports the changes made in 3e15a5e44d8ff761ff68f366c66e8702c02be913 to also happen in 2D; fixes #328.
* fixes two issues with `getImplicit . polygon`:
    * when given two equal points in a row, it used to produce `NaN`; fixes #335
    * when given zero points, it would crash with a `minimum: empty list`; fixes #334 
* these fixes allow us to reenable the `"difference is complement"` test for 2D

Additionally, it:

* cleans up the generator and shrinkers for 2d polygons
* fixes a missed specialization I accidentally introduced in #324 
* removes `epsilon`, which I forgot to delete in #326