### PR TITLE
Call rebound3 in getMesh instead of symbolicGetMesh

### DIFF
--- a/Graphics/Implicit/Export/MarchingSquaresFill.hs
+++ b/Graphics/Implicit/Export/MarchingSquaresFill.hs
@@ -7,7 +7,11 @@ module Graphics.Implicit.Export.MarchingSquaresFill (getContourMesh) where
 
 import Prelude(fmap, Bool(True, False), ($), (-), (+), (/), (*), (<=), ceiling, max, div, floor)
 
-import Graphics.Implicit.Definitions (ℕ, ℝ, ℝ2, Polytri(Polytri), Obj2, (⋯/), (⋯*), fromℕtoℝ, fromℕ)
+import Graphics.Implicit.Definitions (ℕ, ℝ, ℝ2, Polytri(Polytri), Obj2, SymbolicObj2, (⋯/), (⋯*), fromℕtoℝ, fromℕ)
+
+import Graphics.Implicit.Export.Symbolic.Rebound2 (rebound2)
+
+import Graphics.Implicit.ObjectUtil (getBox2, getImplicit2)
 
 import Linear ( V2(V2) )
 
@@ -19,9 +23,12 @@ import Data.Foldable (fold)
 import Control.Parallel.Strategies (using, rdeepseq, parBuffer, parList)
 
 -- | Get an array of triangles describing the interior of a 2D object.
-getContourMesh :: ℝ2 -> ℝ2 -> ℝ2 -> Obj2 -> [Polytri]
-getContourMesh p1 p2 res obj =
+getContourMesh :: ℝ2 -> SymbolicObj2 -> [Polytri]
+getContourMesh res symObj =
     let
+        -- Grow bounds a little to avoid sampling at exact bounds
+        (obj, (p1, p2)) = rebound2 (getImplicit2 symObj, getBox2 symObj)
+
         -- | How much space are we rendering?
         d = p2 - p1
 

--- a/Graphics/Implicit/Export/Render.hs
+++ b/Graphics/Implicit/Export/Render.hs
@@ -10,7 +10,13 @@ module Graphics.Implicit.Export.Render (getMesh, getContour) where
 
 import Prelude((-), ceiling, ($), (+), (*), max, div, tail, fmap, reverse, (.), foldMap, min, Int, (<>), (<$>))
 
-import Graphics.Implicit.Definitions (ℝ, ℕ, Fastℕ, ℝ2, ℝ3, TriangleMesh, Obj2, Obj3, Polyline(Polyline), (⋯/), fromℕtoℝ, fromℕ)
+import Graphics.Implicit.Definitions (ℝ, ℕ, Fastℕ, ℝ2, ℝ3, TriangleMesh, Obj2, SymbolicObj2, Obj3, SymbolicObj3, Polyline(Polyline), (⋯/), fromℕtoℝ, fromℕ)
+
+import Graphics.Implicit.Export.Symbolic.Rebound2 (rebound2)
+
+import Graphics.Implicit.Export.Symbolic.Rebound3 (rebound3)
+
+import Graphics.Implicit.ObjectUtil (getBox2, getImplicit2, getBox3, getImplicit3)
 
 import Data.Foldable(fold)
 import Linear ( V3(V3), V2(V2) )
@@ -66,9 +72,12 @@ import Graphics.Implicit.Export.Render.HandlePolylines (cleanLoopsFromSegs)
 -- Set the default types for the numbers in this file.
 default (ℕ, Fastℕ, ℝ)
 
-getMesh :: ℝ3 -> ℝ3 -> ℝ3 -> Obj3 -> TriangleMesh
-getMesh p1@(V3 x1 y1 z1) p2 res@(V3 xres yres zres) obj =
+getMesh :: ℝ3 -> SymbolicObj3 -> TriangleMesh
+getMesh res@(V3 xres yres zres) symObj =
     let
+        -- Grow bounds a little to avoid sampling at exact bounds
+        (obj, (p1@(V3 x1 y1 z1), p2)) = rebound3 (getImplicit3 symObj, getBox3 symObj)
+
         -- How much space are we rendering?
         d = p2 - p1
 
@@ -177,9 +186,12 @@ getMesh p1@(V3 x1 y1 z1) p2 res@(V3 xres yres zres) obj =
       mergedSquareTris . fold . fold $ fold sqTris
 
 -- | getContour gets a polyline describing the edge of a 2D object.
-getContour :: ℝ2 -> ℝ2 -> ℝ2 -> Obj2 -> [Polyline]
-getContour p1@(V2 x1 y1) p2 res@(V2 xres yres) obj =
+getContour :: ℝ2 -> SymbolicObj2 -> [Polyline]
+getContour res@(V2 xres yres) symObj =
     let
+        -- Grow bounds a little to avoid sampling at exact bounds
+        (obj, (p1@(V2 x1 y1), p2)) = rebound2 (getImplicit2 symObj, getBox2 symObj)
+
         -- | The size of the region we're being asked to search.
         d = p2 - p1
 

--- a/Graphics/Implicit/Export/SymbolicObj2.hs
+++ b/Graphics/Implicit/Export/SymbolicObj2.hs
@@ -16,9 +16,7 @@ import Linear ( Metric(norm), V2(V2), (^/) )
 
 import Graphics.Implicit.Export.MarchingSquaresFill (getContourMesh)
 
-import Graphics.Implicit.ObjectUtil (getImplicit2, getBox2)
-
-import Graphics.Implicit.Export.Symbolic.Rebound2 (rebound2)
+import Graphics.Implicit.ObjectUtil (getImplicit2)
 
 import Graphics.Implicit.Export.Render (getContour)
 
@@ -53,8 +51,7 @@ symbolicGetContour res (Circle r) =
 symbolicGetContour res (Shared2 (Translate v obj)) = appOpPolylines (+ v) $ symbolicGetContour res obj
 symbolicGetContour res (Shared2 (Scale s@(V2 a b) obj)) = appOpPolylines (⋯* s) $ symbolicGetContour (res/sc) obj
     where sc = max a b
-symbolicGetContour res obj = case rebound2 (getImplicit2 obj, getBox2 obj) of
-    (obj', (a,b)) -> getContour a b (pure res) obj'
+symbolicGetContour res obj = getContour (pure res) obj
 
 appOpPolylines :: (ℝ2 -> ℝ2) -> [Polyline] -> [Polyline]
 appOpPolylines op = fmap (appOpPolyline op)
@@ -78,5 +75,4 @@ symbolicGetContourMesh res (Circle r) =
     where
       n :: Fastℕ
       n = max 5 $ ceiling $ 2*pi*r/res
-symbolicGetContourMesh res obj = case rebound2 (getImplicit2 obj, getBox2 obj) of
-    (obj', (a,b)) -> getContourMesh a b (pure res) obj'
+symbolicGetContourMesh res obj = getContourMesh (pure res) obj

--- a/Graphics/Implicit/Export/SymbolicObj3.hs
+++ b/Graphics/Implicit/Export/SymbolicObj3.hs
@@ -11,9 +11,8 @@ import Prelude(pure, zip, length, filter, (>), ($), null, (<>), foldMap, (.), (<
 
 import Graphics.Implicit.Definitions (ℝ, ℝ3, SymbolicObj3(Shared3), SharedObj(UnionR), Triangle, TriangleMesh(TriangleMesh))
 import Graphics.Implicit.Export.Render (getMesh)
-import Graphics.Implicit.ObjectUtil (getBox3, getImplicit3)
+import Graphics.Implicit.ObjectUtil (getBox3)
 import Graphics.Implicit.MathUtil(box3sWithin)
-import Graphics.Implicit.Export.Symbolic.Rebound3 (rebound3)
 
 import Control.Arrow(first, second)
 
@@ -32,18 +31,14 @@ symbolicGetMesh res inputObj@(Shared3 (UnionR r objs)) = TriangleMesh $
 
         (dependants, independents) = sepFree boxedObjs
     in if null independents
-    then case rebound3 (getImplicit3 inputObj, getBox3 inputObj) of
-        (obj, (a,b)) -> unmesh $ getMesh a b (pure res) obj
-    else if null dependants
-    then foldMap (unmesh . symbolicGetMesh res) independents
-    else  foldMap (unmesh . symbolicGetMesh res) independents
-        <> unmesh (symbolicGetMesh res (Shared3 (UnionR r dependants)))
+          then unmesh $ getMesh (pure res) inputObj
+          else if null dependants
+                  then foldMap (unmesh . symbolicGetMesh res) independents
+                  else foldMap (unmesh . symbolicGetMesh res) independents
+                       <> unmesh (symbolicGetMesh res (Shared3 (UnionR r dependants)))
 
 -- | If all that fails, coerce and apply marching cubes :(
-symbolicGetMesh res obj =
-  -- Use rebound3 to stretch bounding box.
-  case rebound3 (getImplicit3 obj, getBox3 obj) of
-    (obj', (a,b)) -> getMesh a b (pure res) obj'
+symbolicGetMesh res obj = getMesh (pure res) obj
 
 unmesh :: TriangleMesh -> [Triangle]
 unmesh (TriangleMesh m) = m


### PR DESCRIPTION
Allows deduplicating `symbolicGetMesh` code a little.

Looks like 2D could use the same treatment if you think it's worth it.