### PR TITLE
Re-export Linears V2, V3 from Graphics.Implicit

### DIFF
--- a/Graphics/Implicit.hs
+++ b/Graphics/Implicit.hs
@@ -77,7 +77,11 @@ module Graphics.Implicit (
   writeOBJ,
   writeTHREEJS,
   writeSCAD3,
-  writePNG3
+  writePNG3,
+
+  -- * Linear re-exports
+  L.V2(V2),
+  L.V3(V3)
 ) where
 
 import Prelude(FilePath, IO)
@@ -94,6 +98,8 @@ import Graphics.Implicit.Definitions as W (ℝ, ℝ2, ℝ3, SymbolicObj2, Symbol
 
 -- Functions for writing files based on the result of operations on primitives.
 import qualified Graphics.Implicit.Export as Export (writeSVG, writeDXF2, writeSTL, writeBinSTL, writeOBJ, writeSCAD2, writeSCAD3, writeTHREEJS, writeGCodeHacklabLaser, writePNG)
+
+import Linear as L (V2(V2), V3(V3), Quaternion(Quaternion))
 
 -- We want Export to be a bit less polymorphic
 -- (so that types will collapse nicely)

--- a/tests/GoldenSpec/Spec.hs
+++ b/tests/GoldenSpec/Spec.hs
@@ -7,7 +7,6 @@ import GoldenSpec.Util (golden)
 import Graphics.Implicit
 import Prelude
 import Test.Hspec ( describe, Spec )
-import Linear
 
 default (Int)
 


### PR DESCRIPTION
So users don't need to import Linear for simple programs.