### PR TITLE
Remove the O(n^2) recursive case from getLoops

### DIFF
--- a/Graphics/Implicit/Export/Render.hs
+++ b/Graphics/Implicit/Export/Render.hs
@@ -8,7 +8,7 @@
 -- export getContour and getMesh, which returns the edge of a 2D object, or the surface of a 3D object, respectively.
 module Graphics.Implicit.Export.Render (getMesh, getContour) where
 
-import Prelude((-), ceiling, ($), (+), (*), max, div, tail, fmap, reverse, (.), foldMap, min, Int, (<>), (<$>))
+import Prelude(error, (-), ceiling, ($), (+), (*), max, div, tail, fmap, reverse, (.), foldMap, min, Int, (<>), (<$>))
 
 import Graphics.Implicit.Definitions (ℝ, ℕ, Fastℕ, ℝ2, ℝ3, TriangleMesh, Obj2, SymbolicObj2, Obj3, SymbolicObj3, Polyline(Polyline), (⋯/), fromℕtoℝ, fromℕ)
 
@@ -68,6 +68,7 @@ import Control.Parallel.Strategies (using, rdeepseq, parBuffer)
 
 -- For the 2D case, we need one last thing, cleanLoopsFromSegs:
 import Graphics.Implicit.Export.Render.HandlePolylines (cleanLoopsFromSegs)
+import Data.Maybe (fromMaybe)
 
 -- Set the default types for the numbers in this file.
 default (ℕ, Fastℕ, ℝ)
@@ -161,7 +162,8 @@ getMesh res@(V3 xres yres zres) symObj =
         -- FIXME: hack.
         minres = xres `min` yres `min` zres
         sqTris = [[[
-            foldMap (tesselateLoop minres obj) $ getLoops $
+            foldMap (tesselateLoop minres obj) $
+              fromMaybe (error "unclosed loop in paths given") $ getLoops $
                         segX''' <>
                    mapR segX''T <>
                    mapR segY''' <>

--- a/Graphics/Implicit/Export/Render/GetLoops.hs
+++ b/Graphics/Implicit/Export/Render/GetLoops.hs
@@ -11,13 +11,13 @@ import Data.List (partition)
 
 -- | The goal of getLoops is to extract loops from a list of segments.
 --   The input is a list of segments.
---   The output a list of loops, where each loop is a list of 
+--   The output a list of loops, where each loop is a list of
 --   segments, which each piece representing a "side".
 
 -- For example:
--- Given points [[1,2],[5,1],[3,4,5], ... ] 
+-- Given points [[1,2],[5,1],[2,3,4,5], ... ]
 -- notice that there is a loop 1,2,3,4,5... <repeat>
--- But we give the output [ [ [1,2], [3,4,5], [5,1] ], ... ]
+-- But we give the output [ [ [1,2], [2,3,4,5], [5,1] ], ... ]
 -- so that we have the loop, and also knowledge of how
 -- the list is built (the "sides" of it).
 

--- a/implicit.cabal
+++ b/implicit.cabal
@@ -122,6 +122,8 @@ Library
                     Graphics.Implicit.Export.DiscreteAproxable
                     -- These are exposed for docgen.
                     Graphics.Implicit.ExtOpenScad.Primitives
+                    -- These are exposed for testing
+                    Graphics.Implicit.Export.Render.GetLoops
     Other-modules:
                   Graphics.Implicit.FastIntUtil
                   Graphics.Implicit.IntegralUtil
@@ -148,7 +150,6 @@ Library
                   Graphics.Implicit.Export.Symbolic.Rebound3
                   Graphics.Implicit.Export.Render
                   Graphics.Implicit.Export.Render.Definitions
-                  Graphics.Implicit.Export.Render.GetLoops
                   Graphics.Implicit.Export.Render.GetSegs
                   Graphics.Implicit.Export.Render.HandleSquares
                   Graphics.Implicit.Export.Render.Interpolate
@@ -225,7 +226,8 @@ Test-suite test-implicit
                   hw-hspec-hedgehog,
                   quickspec,
                   QuickCheck,
-                  linear
+                  linear,
+                  lens
     Other-Modules:
                   ParserSpec.Expr
                   ParserSpec.Statement
@@ -241,6 +243,7 @@ Test-suite test-implicit
                   Graphics.Implicit.Test.Instances
                   Graphics.Implicit.Test.Utils
                   ImplicitSpec
+                  TesselationSpec
 
 Benchmark parser-bench
     Import: binstuff

--- a/implicit.cabal
+++ b/implicit.cabal
@@ -239,6 +239,7 @@ Test-suite test-implicit
                   GoldenSpec.Spec
                   GoldenSpec.Util
                   Graphics.Implicit.Test.Instances
+                  Graphics.Implicit.Test.Utils
                   ImplicitSpec
 
 Benchmark parser-bench

--- a/tests/Graphics/Implicit/Test/Utils.hs
+++ b/tests/Graphics/Implicit/Test/Utils.hs
@@ -1,0 +1,13 @@
+module Graphics.Implicit.Test.Utils where
+
+import Prelude (drop, (<*>), (<$>), take, length, pure)
+import Test.QuickCheck ( choose, Gen )
+
+
+randomGroups :: [a] -> Gen [[a]]
+randomGroups [] = pure []
+randomGroups as = do
+  n <- choose (1, length as)
+  (:) <$> pure (take n as)
+      <*> randomGroups (drop n as)
+

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -24,6 +24,7 @@ import PropertySpec (propSpec)
 
 import qualified GoldenSpec.Spec as Golden
 import qualified ImplicitSpec as Implicit
+import qualified TesselationSpec as Tesselation
 
 main :: IO ()
 main = hspec $ do
@@ -42,3 +43,5 @@ main = hspec $ do
   describe "property tests" propSpec
 
   Implicit.spec
+  Tesselation.spec
+

--- a/tests/TesselationSpec.hs
+++ b/tests/TesselationSpec.hs
@@ -1,0 +1,157 @@
+{-# LANGUAGE BangPatterns     #-}
+{-# LANGUAGE DeriveGeneric    #-}
+{-# LANGUAGE ImplicitPrelude  #-}
+{-# LANGUAGE TupleSections    #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns     #-}
+
+module TesselationSpec (spec) where
+
+import Test.Hspec
+    (describe, shouldBe, shouldContain, Spec, Expectation )
+import Test.QuickCheck (Gen, Positive(), arbitrary, choose, getPositive, shuffle)
+import Data.Foldable ( for_ )
+import Test.Hspec.QuickCheck (prop)
+import Data.List (sort, group)
+import Data.Traversable ( for )
+import Graphics.Implicit.Export.Render.GetLoops (getLoops)
+import Graphics.Implicit.Test.Utils (randomGroups)
+import Graphics.Implicit.Test.Instances ()
+import Control.Monad (join)
+import Control.Lens (Ixed(ix), (&), (.~) )
+
+
+spec :: Spec
+spec = do
+  describe "getLoops" $ do
+    prop "stability" $ do
+      n <- choose (2, 20)
+      (_, segs) <- genManyLoops @Int 0 n
+      -- Shuffle the loops amongst themselves (but dont intermingle their segments)
+      shuffled_segs <- shuffle segs
+      pure $ do
+        Just loops <- pure $ getLoops $ join shuffled_segs
+        -- The discovered loops should be in the same order that we generated
+        -- them in
+        for_ (zip loops shuffled_segs) $ \(loop, seg) ->
+          head loop `shouldBe` head seg
+
+    prop "loops a loop" $ do
+      (v, segs) <- genLoop @Int 0
+      pure $ do
+        Just [loop] <- pure $ getLoops segs
+        proveLoop v loop
+
+    prop "loops many loops" $ do
+      -- Pick a number of loops to aim for
+      n <- choose (2, 20)
+      (vs, segs) <- genManyLoops @Int 0 n
+
+      -- Shuffle the segments of all the loops together
+      shuffled_segs <- shuffle $ join segs
+      pure $ do
+        Just loops <- pure $ getLoops shuffled_segs
+        -- Make sure we have the right length
+        length loops `shouldBe` n
+        -- Ensure that we can 'proveLoop' on each loop
+        for_ (zip vs $ sort loops) $ uncurry proveLoop
+
+    prop "inserting in the middle is ok" $ do
+      (_, segs) <- genLoop @Int 0
+      let n = length segs
+      -- Pick a random segment
+      seg_idx <- choose (0, n - 1)
+      -- Insert a random element into it
+      seg' <- insertMiddle (segs !! seg_idx) =<< arbitrary
+      let segs' = segs & ix seg_idx .~ seg'
+
+      pure $ do
+        -- We should be able to get the loops of the original and inserted segments.
+        Just [loop] <- pure $ getLoops segs
+        Just [loop'] <- pure $ getLoops segs'
+        -- Really we're just testing to make sure the above pattern match doesn't
+        -- 'fail', but let's make sure they have the same number of segments too.
+        length loop `shouldBe` length loop'
+
+
+
+------------------------------------------------------------------------------
+-- | Show that the given loop exists somewhere in the discovered loops.
+-- Correctly deals with the case where the two loops start at different places.
+proveLoop :: (Show a, Eq a) => [a] -> [[a]] -> Expectation
+proveLoop v loops =
+  join (replicate 2 v) `shouldContain` unloop loops
+
+
+------------------------------------------------------------------------------
+-- | Generate a loop and random segments that should produce it. The defining
+-- equation of this generator is tested by "getLoops > loops a loop".
+genLoop
+    :: Enum a
+    => a
+    -> Gen ([a], [[a]])  -- ^ @(loop, segments)@
+genLoop start = do
+  n <- getPositive <$> arbitrary @(Positive Int)
+  let v = take n $ enumFrom start
+  bits <- randomGroups v
+  let segs = loopify bits
+  shuffled_segs <- shuffle segs
+  pure (v, shuffled_segs)
+
+
+------------------------------------------------------------------------------
+-- | Like 'genLoop', but produces several loops, tagged with an index number.
+-- For best results, you should call @shuffle . join@ on the resulting segments
+-- before calling @getLoops@ on it, to ensure the segments are intermingled
+-- between the loops.
+genManyLoops
+    :: Enum a
+    => a
+    -> Int  -- ^ Number of loops to generate
+    -> Gen ([[(Int, a)]], [[[(Int, a)]]])  -- ^ @(loop, segments)@
+genManyLoops start n = do
+  fmap unzip $ for [0 .. n - 1] $ \idx -> do
+    -- Generate a loop for each
+    (v, segs) <- genLoop start
+    -- and tag it with the index
+    pure (fmap (idx,) v, fmap (fmap (idx,)) segs)
+
+
+------------------------------------------------------------------------------
+-- | Given a list of lists, insert elements into the 'head' and 'last' of each
+-- sub-list so that the 'last' of one list is the 'head' of the next.
+loopify :: [[a]] -> [[a]]
+loopify as = zipWith (\a -> mappend a . take 1) as $ drop 1 $ join $ repeat as
+
+
+------------------------------------------------------------------------------
+-- | Remove sequential elements in a list. Additionally, this function removes
+-- the 'head' of the list, because conceptully it is also the 'last'.
+unloop :: Eq a => [[a]] -> [a]
+unloop = drop 1 . fmap head . group . join
+
+
+------------------------------------------------------------------------------
+-- | Insert an element into the middle (not 'head' or 'last') of a list.
+insertMiddle :: [a] -> a -> Gen [a]
+insertMiddle [] _ = pure []
+insertMiddle [a] _ = pure [a]
+insertMiddle as a = do
+  let n = length as
+  i <- choose (1, n - 1)
+  pure $ insertAt i a as
+
+
+------------------------------------------------------------------------------
+-- | Helper function to insert an element into a list at a given position.
+--
+-- Stolen from https://hackage.haskell.org/package/ilist-0.4.0.1/docs/Data-List-Index.html#v:insertAt
+insertAt :: Int -> a -> [a] -> [a]
+insertAt i a ls
+  | i < 0 = ls
+  | otherwise = go i ls
+  where
+    go 0 xs     = a : xs
+    go n (x:xs) = x : go (n-1) xs
+    go _ []     = []
+


### PR DESCRIPTION
The old implementation of `getLoops` calls `last . last` as it recurses, which is `O(n^2)`. Sounds maybe ok, except when you realize that it's being called in the context of [a tight O(r^3) loop](https://github.com/colah/ImplicitCAD/blob/2218fc4ef490d6002d1cd90d409274fdd760e93a/Graphics/Implicit/Export/Render.hs#L163-L182). 

This PR improves this particular issue to linear time, by tracking the last element as we go through. The underlying code is still snocing lists, so this isn't a full fix, but one step at a time. This PR also pushes the partiality of `getLoops'` upwards into `getMesh`, allowing us to test the former without fear of exceptions. Oh yeah, and there are tests!