### PR TITLE
Remove ExtrudeRotateR

### DIFF
--- a/Graphics/Implicit/Definitions.hs
+++ b/Graphics/Implicit/Definitions.hs
@@ -51,7 +51,6 @@ module Graphics.Implicit.Definitions (
         Cylinder,
         Rotate3,
         ExtrudeR,
-        ExtrudeRotateR,
         ExtrudeRM,
         ExtrudeOnEdgeOf,
         RotateExtrude,
@@ -303,7 +302,6 @@ data SymbolicObj3 =
     | Rotate3 (Quaternion ℝ) SymbolicObj3
     -- 2D based
     | ExtrudeR ℝ SymbolicObj2 ℝ
-    | ExtrudeRotateR ℝ ℝ SymbolicObj2 ℝ
     | ExtrudeRM
         ℝ                     -- rounding radius
         (Either ℝ (ℝ -> ℝ))   -- twist
@@ -336,8 +334,6 @@ instance Show SymbolicObj3 where
       showCon "cylinder2" @| r1 @| r2 @| h
     Rotate3 qd s -> showCon "rotate3" @| quaternionToEuler qd @| s
     ExtrudeR d s d2 -> showCon "extrudeR" @| d @| s @| d2
-    ExtrudeRotateR d d1 s d3 ->
-      showCon "extrudeRotateR" @| d @| d1 @| s @| d3
     ExtrudeRM d edfdd e ep_ddfdp_dd s edfp_ddd ->
       showCon "extrudeRM" @| d @|| edfdd @| e @|| ep_ddfdp_dd @| s @|| edfp_ddd
     RotateExtrude d md ep_ddfdp_dd edfdd s ->

--- a/Graphics/Implicit/Export/SymbolicFormats.hs
+++ b/Graphics/Implicit/Export/SymbolicFormats.hs
@@ -11,7 +11,7 @@ module Graphics.Implicit.Export.SymbolicFormats (scad2, scad3) where
 
 import Prelude((.), fmap, Either(Left, Right), ($), (*), ($!), (-), (/), pi, error, (+), (==), take, floor, (&&), const, pure, (<>), sequenceA, (<$>))
 
-import Graphics.Implicit.Definitions(ℝ, SymbolicObj2(Shared2, SquareR, Circle, PolygonR, Rotate2), SymbolicObj3(Shared3, CubeR, Sphere, Cylinder, Rotate3, ExtrudeR, ExtrudeRotateR, ExtrudeRM, RotateExtrude, ExtrudeOnEdgeOf), isScaleID, SharedObj(Empty, Full, Complement, UnionR, IntersectR, DifferenceR, Translate, Scale, Mirror, Outset, Shell, EmbedBoxedObj), quaternionToEuler)
+import Graphics.Implicit.Definitions(ℝ, SymbolicObj2(Shared2, SquareR, Circle, PolygonR, Rotate2), SymbolicObj3(Shared3, CubeR, Sphere, Cylinder, Rotate3, ExtrudeR, ExtrudeRM, RotateExtrude, ExtrudeOnEdgeOf), isScaleID, SharedObj(Empty, Full, Complement, UnionR, IntersectR, DifferenceR, Translate, Scale, Mirror, Outset, Shell, EmbedBoxedObj), quaternionToEuler)
 import Graphics.Implicit.Export.TextBuilderUtils(Text, Builder, toLazyText, fromLazyText, bf)
 
 import Control.Monad.Reader (Reader, runReader, ask)
@@ -134,7 +134,6 @@ buildS3 (Rotate3 q obj) =
 
 buildS3 (ExtrudeR r obj h) | r == 0 = callNaked "linear_extrude" ["height = " <> bf h] [buildS2 obj]
 
-buildS3 (ExtrudeRotateR r twist obj h) | r == 0 = callNaked "linear_extrude" ["height = " <> bf h, "twist = " <> bf twist] [buildS2 obj]
 
 -- FIXME: handle scale, center.
 buildS3 (ExtrudeRM r twist scale (Left translate) obj (Left height)) | r == 0 && isScaleID scale && translate == V2 0 0 = do
@@ -155,7 +154,6 @@ buildS3 (ExtrudeRM r twist scale (Left translate) obj (Left height)) | r == 0 &&
 
 buildS3 CubeR{} = error "cannot provide roundness when exporting openscad; unsupported in target format."
 buildS3 ExtrudeR{} = error "cannot provide roundness when exporting openscad; unsupported in target format."
-buildS3 ExtrudeRotateR {} = error "cannot provide roundness when exporting openscad; unsupported in target format."
 buildS3 ExtrudeRM{} = error "cannot provide roundness when exporting openscad; unsupported in target format."
 buildS3 RotateExtrude{} = error "cannot provide roundness when exporting openscad; unsupported in target format."
 buildS3(ExtrudeOnEdgeOf _ _) = error "cannot provide roundness when exporting openscad; unsupported in target format."

--- a/Graphics/Implicit/ObjectUtil/GetBox3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetBox3.hs
@@ -5,13 +5,13 @@
 
 module Graphics.Implicit.ObjectUtil.GetBox3 (getBox3) where
 
-import Prelude(uncurry, pure, Bool(False), Either (Left, Right), (==), max, (/), (-), (+), fmap, unzip, ($), (<$>), (.), minimum, maximum, min, (>), (*), (<), abs, either, error, const, otherwise, take, fst, snd)
+import Prelude(uncurry, pure, Bool(False), Either (Left, Right), (==), max, (/), (-), (+), fmap, unzip, ($), (<$>), (.), minimum, maximum, min, (>), (*), (<), abs, either, const, otherwise, take, fst, snd)
 
 import Graphics.Implicit.Definitions
     ( Fastℕ,
       fromFastℕ,
       ExtrudeRMScale(C2, C1),
-      SymbolicObj3(Shared3, CubeR, Sphere, Cylinder, Rotate3, ExtrudeR, ExtrudeOnEdgeOf, ExtrudeRM, RotateExtrude, ExtrudeRotateR),
+      SymbolicObj3(Shared3, CubeR, Sphere, Cylinder, Rotate3, ExtrudeR, ExtrudeOnEdgeOf, ExtrudeRM, RotateExtrude),
       Box3,
       ℝ,
       fromFastℕtoℝ,
@@ -144,8 +144,6 @@ getBox3 (RotateExtrude rot _ (Right f) rotate symbObj) =
             else (x2 + xmax', y1 + ymin', y2 + ymax')
     in
         (V3 (-r) (-r) $ y1 + ymin', V3 r  r  $ y2 + ymax')
--- FIXME: add case for ExtrudeRotateR!
-getBox3 ExtrudeRotateR{} = error "ExtrudeRotateR implementation incomplete!"
 
 
 unpack :: V2 a -> (a, a)

--- a/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
@@ -5,10 +5,10 @@
 
 module Graphics.Implicit.ObjectUtil.GetImplicit3 (getImplicit3) where
 
-import Prelude (Either(Left, Right), abs, (-), (/), (*), sqrt, (+), atan2, max, cos, minimum, ($), sin, pi, (.), Bool(True, False), ceiling, floor, pure, error, (==), otherwise)
+import Prelude (Either(Left, Right), abs, (-), (/), (*), sqrt, (+), atan2, max, cos, minimum, ($), sin, pi, (.), Bool(True, False), ceiling, floor, pure, (==), otherwise)
 
 import Graphics.Implicit.Definitions
-    ( ℕ, SymbolicObj3(CubeR, Sphere, Cylinder, Rotate3, ExtrudeR, ExtrudeRM, ExtrudeOnEdgeOf, RotateExtrude, Shared3, ExtrudeRotateR), Obj3, ℝ2, ℝ, fromℕtoℝ, toScaleFn )
+    ( ℕ, SymbolicObj3(CubeR, Sphere, Cylinder, Rotate3, ExtrudeR, ExtrudeRM, ExtrudeOnEdgeOf, RotateExtrude, Shared3), Obj3, ℝ2, ℝ, fromℕtoℝ, toScaleFn )
 
 import Graphics.Implicit.MathUtil ( rmax, rmaximum )
 
@@ -150,7 +150,3 @@ getImplicit3 (RotateExtrude totalRotation round translate rotate symbObj) =
               else obj rz_pos
 getImplicit3 (Shared3 obj) = getImplicitShared obj
 
-
--- FIXME: implement this, or implement a fallthrough function.
---getImplicit3 (ExtrudeRotateR) =
-getImplicit3 ExtrudeRotateR{} = error "ExtrudeRotateR unimplimented!"

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -22,7 +22,6 @@ module Graphics.Implicit.Primitives (
                                      getImplicit,
                                      extrudeR,
                                      extrudeRM,
-                                     extrudeRotateR,
                                      extrudeOnEdgeOf,
                                      sphere,
                                      cubeR, rect3R,
@@ -76,7 +75,6 @@ import Graphics.Implicit.Definitions (ℝ, ℝ2, ℝ3, Box2,
                                                    Cylinder,
                                                    Rotate3,
                                                    ExtrudeR,
-                                                   ExtrudeRotateR,
                                                    ExtrudeRM,
                                                    RotateExtrude,
                                                    ExtrudeOnEdgeOf,
@@ -342,10 +340,6 @@ extrudeR
     -> ℝ   -- ^ Extrusion height
     -> SymbolicObj3
 extrudeR = ExtrudeR
-
--- | This function is not implemented
-extrudeRotateR :: ℝ -> ℝ -> SymbolicObj2 -> ℝ -> SymbolicObj3
-extrudeRotateR = ExtrudeRotateR
 
 extrudeRM :: ℝ              -- ^ rounding radius (in mm)
     -> Either ℝ (ℝ -> ℝ)    -- ^ twist


### PR DESCRIPTION
`ExtrudeRotateR` was added back in 2012:

https://github.com/colah/ImplicitCAD/commit/6cca883a315bbdc15994e35d0d4b56e64d0db9b4#diff-d86ba3127eae4fb51dd978bbefd27f82f4d07ba85a51436729b1f367bd15e7a0R98

but hasn't done anything except call `error` since then.

Fixes #363 