### PR TITLE
Fix cylinders of zero and negative heights

### DIFF
--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -47,7 +47,7 @@ module Graphics.Implicit.Primitives (
                                      Object
                                     ) where
 
-import Prelude(id, Num, (+), (-), (*), (/), (.), negate, Bool(True, False), Maybe(Just, Nothing), Either, fmap, ($))
+import Prelude(abs, (<), otherwise, id, Num, (+), (-), (*), (/), (.), negate, Bool(True, False), Maybe(Just, Nothing), Either, fmap, ($))
 
 import Graphics.Implicit.Definitions (ObjectContext, ℝ, ℝ2, ℝ3, Box2,
                                       SharedObj(Empty,
@@ -124,7 +124,10 @@ cylinder2 ::
     -> ℝ                -- ^ Height of the cylinder
     -> SymbolicObj3     -- ^ Resulting cylinder
 
-cylinder2 r1 r2 h = Cylinder h r1 r2
+cylinder2 _ _ 0 = emptySpace  -- necessary to prevent a NaN
+cylinder2 r1 r2 h
+  | h < 0 = mirror (V3 0 0 1) $ cylinder2 r1 r2 (abs h)
+  | otherwise = Cylinder h r1 r2
 
 cylinder ::
     ℝ                   -- ^ Radius of the cylinder

--- a/tests/ImplicitSpec.hs
+++ b/tests/ImplicitSpec.hs
@@ -38,6 +38,8 @@ import Linear ( V3(V3), (^*) )
 import Graphics.Implicit (unionR)
 import Graphics.Implicit (intersectR)
 import Graphics.Implicit (extrude)
+import Graphics.Implicit (cylinder2)
+import Graphics.Implicit (mirror)
 
 
 ------------------------------------------------------------------------------
@@ -232,6 +234,9 @@ misc3dSpec = describe "misc 3d tests" $ do
   prop "object-rounding value doesn't jump from 3d to 2d" $ \r obj ->
     withRounding r . extrude obj
       =~= withRounding r . extrude (withRounding 0 obj)
+
+  prop "cylinder with negative height is a flipped cylinder with positive height" $ \r1 r2 h ->
+    cylinder2 r1 r2 h =~= mirror (V3 0 0 1) (cylinder2 r1 r2 (-h))
 
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Cylinders of negative height are now governed by the equation

`cylinder2 r1 r2 h = mirror (V3 0 0 1) $ cylinder2 r1 r2 (-h)`  

Fixes #340