### PR TITLE
Cleanup haddocks

### DIFF
--- a/Graphics/Implicit/Export/DiscreteAproxable.hs
+++ b/Graphics/Implicit/Export/DiscreteAproxable.hs
@@ -58,7 +58,7 @@ instance DiscreteAproxable SymbolicObj3 NormedTriangleMesh where
 instance DiscreteAproxable SymbolicObj3 DynamicImage where
     discreteAprox _ symbObj = ImageRGBA8 $ generateImage pixelRenderer (round w) (round h)
         where
-            -- | Size of the image to produce.
+            -- Size of the image to produce.
             (V2 w h) = V2 150 150 :: ℝ2
             obj = getImplicit symbObj
             box@(V3 x1 y1 z1, V3 _ y2 z2) = getBox3 symbObj
@@ -70,7 +70,7 @@ instance DiscreteAproxable SymbolicObj3 DynamicImage where
             camera = Camera (V3 (x1-deviation*2.2) avY avZ) (V3 0 (-1) 0) (V3 0 0 (-1)) 1.0
             lights = [Light (V3 (x1-deviation*1.5) (y1 - 0.4*(y2-y1)) avZ) (0.03*deviation) ]
             scene = Scene obj (Color 200 200 230 255) lights (Color 255 255 255 0)
-            -- | passed to generateImage, it's external, and determines this type.
+            -- passed to generateImage, it's external, and determines this type.
             pixelRenderer :: Int -> Int -> PixelRGBA8
             pixelRenderer a b = renderScreen
                 (fromIntegral a/w - 0.5) (fromIntegral b/h - 0.5)
@@ -103,13 +103,13 @@ instance DiscreteAproxable SymbolicObj2 [Polyline] where
 instance DiscreteAproxable SymbolicObj2 DynamicImage where
     discreteAprox _ symbObj = ImageRGBA8 $ generateImage pixelRenderer (round w) (round h)
         where
-            -- | Size of the image to produce.
+            -- Size of the image to produce.
             V2 w h = pure 150 :: ℝ2
             obj = getImplicit symbObj
             (p1@(V2 x1 _), p2@(V2 _ y2)) = getBox2 symbObj
             V2 dx dy = p2 - p1
             dxy = max dx dy
-            -- | passed to generateImage, it's external, and determines this type.
+            -- passed to generateImage, it's external, and determines this type.
             pixelRenderer :: Int -> Int -> PixelRGBA8
             pixelRenderer mya myb = mycolor
                 where

--- a/Graphics/Implicit/Export/NormedTriangleMeshFormats.hs
+++ b/Graphics/Implicit/Export/NormedTriangleMeshFormats.hs
@@ -20,10 +20,10 @@ import Linear (V3(V3))
 obj :: NormedTriangleMesh -> Text
 obj mesh = toLazyText $ vertcode <> normcode <> trianglecode
     where
-        -- | A vertex line; v (0.0, 0.0, 1.0) = "v 0.0 0.0 1.0\n"
+        -- A vertex line; v (0.0, 0.0, 1.0) = "v 0.0 0.0 1.0\n"
         v :: ℝ3 -> Builder
         v (V3 x y z) = "v "  <> bf x <> " " <> bf y <> " " <> bf z <> "\n"
-        -- | A normal line; n (0.0, 0.0, 1.0) = "vn 0.0 0.0 1.0\n"
+        -- A normal line; n (0.0, 0.0, 1.0) = "vn 0.0 0.0 1.0\n"
         n :: ℝ3 -> Builder
         n (V3 x y z) = "vn " <> bf x <> " " <> bf y <> " " <> bf z <> "\n"
         verts = do

--- a/Graphics/Implicit/Export/Render.hs
+++ b/Graphics/Implicit/Export/Render.hs
@@ -95,22 +95,22 @@ getMesh res@(V3 xres yres zres) symObj =
         pXZ = [ y1 + ry*fromℕtoℝ n | n <- [0.. ny] ]
         pXY = [ z1 + rz*fromℕtoℝ n | n <- [0.. nz] ]
 
-        -- | performance tuning.
+        -- performance tuning.
         -- FIXME: magic number.
         forcesteps :: Int
         forcesteps = 32
 
-        -- | Evaluate obj to avoid waste in mids, segs, later.
+        -- Evaluate obj to avoid waste in mids, segs, later.
         objV = par3DList nx ny nz
 
-        -- | Sample our object(s) at every point in the 3D space given.
+        -- Sample our object(s) at every point in the 3D space given.
         par3DList :: ℕ -> ℕ -> ℕ -> [[[ℝ]]]
         par3DList lenx leny lenz =
             [[[ sample mx my mz
             | mx <- [0..lenx] ] | my <- [0..leny] ] | mz <- [0..lenz] ]
               `using` parBuffer (max 1 $ div (fromℕ $ (lenx+leny+lenz)) forcesteps) rdeepseq
 
-        -- | sample our object(s) at the given point.
+        -- sample our object(s) at the given point.
         sample :: ℕ -> ℕ -> ℕ -> ℝ
         sample mx my mz = obj $
               V3
@@ -198,29 +198,29 @@ getContour res@(V2 xres yres) symObj =
         -- Grow bounds a little to avoid sampling at exact bounds
         (obj, (p1@(V2 x1 y1), p2)) = rebound2 (getImplicit symObj, getBox2 symObj)
 
-        -- | The size of the region we're being asked to search.
+        -- The size of the region we're being asked to search.
         d = p2 - p1
 
-        -- | How many steps will we take on each axis?
+        -- How many steps will we take on each axis?
         nx, ny :: ℕ
         steps@(V2 nx ny) = ceiling <$> (d ⋯/ res)
 
-        -- | How big are the steps?
+        -- How big are the steps?
         (V2 rx ry) = d ⋯/ (fromℕtoℝ <$> steps)
 
         -- The lines we are rendering along.
         pX = [ x1 + rx*fromℕtoℝ p | p <- [0.. nx] ]
         pY = [ y1 + ry*fromℕtoℝ p | p <- [0.. ny] ]
 
-        -- | Performance tuning.
+        -- Performance tuning.
         -- FIXME: magic number.
         forcesteps :: Int
         forcesteps = 32
 
-        -- | Evaluate obj to avoid waste in mids, segs, later.
+        -- Evaluate obj to avoid waste in mids, segs, later.
         objV = par2DList nx ny
 
-        -- | Sample our object(s) at every point in the 2D plane given.
+        -- Sample our object(s) at every point in the 2D plane given.
         par2DList :: ℕ -> ℕ -> [[ℝ]]
         par2DList lenx leny =
             [[ sample mx my
@@ -228,28 +228,28 @@ getContour res@(V2 xres yres) symObj =
                 ] | my <- [0..leny]
                 ] `using` parBuffer (max 1 $ div (fromℕ $ lenx+leny) forcesteps) rdeepseq
 
-        -- | sample our object(s) at the given point.
+        -- sample our object(s) at the given point.
         sample :: ℕ -> ℕ -> ℝ
         sample mx my = obj $
           V2
                 (x1 + rx*fromℕtoℝ mx)
                 (y1 + ry*fromℕtoℝ my)
 
-        -- | Calculate mid points on X axis in 2D space.
+        -- Calculate mid points on X axis in 2D space.
         midsX = [[
                  interpolate (V2 x0 objX0Y0) (V2 x1' objX1Y0) (obj *$ y0) xres
                  | x0 <- pX | x1' <- tail pX | objX0Y0 <- objY0 | objX1Y0 <- tail objY0
                 ]| y0 <- pY |                   objY0   <- objV
                 ] `using` parBuffer (max 1 $ div (fromℕ nx) forcesteps) rdeepseq
 
-        -- | Calculate mid points on Y axis in 2D space.
+        -- Calculate mid points on Y axis in 2D space.
         midsY = [[
                  interpolate (V2 y0 objX0Y0) (V2 y1' objX0Y1) (obj $* x0) yres
                  | x0 <- pX |                  objX0Y0 <- objY0   | objX0Y1 <- objY1
                 ]| y0 <- pY | y1' <- tail pY | objY0   <- objV    | objY1   <- tail objV
                 ] `using` parBuffer (max 1 $ div (fromℕ ny) forcesteps) rdeepseq
 
-        -- | Calculate segments for each side
+        -- Calculate segments for each side
         segs = [[
             getSegs (V2 x0 y0) (V2 x1' y1') obj (objX0Y0, objX1Y0, objX0Y1, objX1Y1) (midA0, midA1, midB0, midB1)
              | x0<-pX | x1'<-tail pX |midB0<-mX''  | midB1<-mX'T       | midA0<-mY''  | midA1<-tail mY'' | objX0Y0<-objY0 | objX1Y0<-tail objY0 | objX0Y1<-objY1 | objX1Y1<-tail objY1

--- a/Graphics/Implicit/Export/Render/GetLoops.hs
+++ b/Graphics/Implicit/Export/Render/GetLoops.hs
@@ -13,26 +13,28 @@ import Data.List (partition)
 --   The input is a list of segments.
 --   The output a list of loops, where each loop is a list of
 --   segments, which each piece representing a "side".
-
+--
 -- For example:
 -- Given points [[1,2],[5,1],[2,3,4,5], ... ]
 -- notice that there is a loop 1,2,3,4,5... <repeat>
 -- But we give the output [ [ [1,2], [2,3,4,5], [5,1] ], ... ]
 -- so that we have the loop, and also knowledge of how
 -- the list is built (the "sides" of it).
-
+--
 getLoops :: Eq a => [[a]] -> Maybe [[[a]]]
 getLoops [] = Just []
 getLoops (a:as) = getLoops' as [a] (last a)
 
--- We will be actually doing the loop extraction with
+-- | We will be actually doing the loop extraction with
 -- getLoops'
-
+--
 -- getLoops' has a first argument of the segments as before,
 -- but a *second argument* which is the loop presently being
 -- built.
-
+--
 -- so we begin with the "building loop" being empty.
+--
+-- see also: 'getLoops'.
 getLoops'
     :: Eq a
     => [[a]]   -- ^ input
@@ -40,13 +42,13 @@ getLoops'
     -> a       -- ^ last element in the accumulator
     -> Maybe [[[a]]]
 
--- | If there aren't any segments, and the "building loop" is empty, produce no loops.
+-- If there aren't any segments, and the "building loop" is empty, produce no loops.
 getLoops' [] [] _ = Just []
 
--- | If the building loop is empty, stick the first segment we have onto it to give us something to build on.
+-- If the building loop is empty, stick the first segment we have onto it to give us something to build on.
 getLoops' (x:xs) [] _ = getLoops' xs [x] (last x)
 
--- | A loop is finished if its start and end are the same.
+-- A loop is finished if its start and end are the same.
 -- Return it and start searching for another loop.
 getLoops' segs workingLoop ultima | head (head workingLoop) == ultima =
     (workingLoop :) <$> getLoops' segs [] ultima

--- a/Graphics/Implicit/Export/Render/HandlePolylines.hs
+++ b/Graphics/Implicit/Export/Render/HandlePolylines.hs
@@ -43,7 +43,7 @@ reducePolyline (Polyline (V2 x1 y1 : V2 x2 y2 : V2 x3 y3:others))
 -- | remove sequential duplicate points.
 reducePolyline (Polyline (V2 x1 y1 : V2 x2 y2 : others)) =
     if (x1,y1) == (x2,y2) then reducePolyline (Polyline (V2 x2 y2 : others)) else Polyline (V2 x1 y1 : V2 x2 y2 : others)
--- | Return the last result.
+-- Return the last result.
 reducePolyline l@(Polyline ((_:_))) = l
 -- Should not happen.
 reducePolyline (Polyline []) = error "empty polyline"

--- a/Graphics/Implicit/Export/SymbolicObj3.hs
+++ b/Graphics/Implicit/Export/SymbolicObj3.hs
@@ -37,5 +37,5 @@ symbolicGetMesh res inputObj@(Shared3 (UnionR r objs)) = TriangleMesh $
                   else foldMap (getTriangles . symbolicGetMesh res) independents
                        <> getTriangles (symbolicGetMesh res (Shared3 (UnionR r dependants)))
 
--- | If all that fails, coerce and apply marching cubes :(
+-- If all that fails, coerce and apply marching cubes :(
 symbolicGetMesh res obj = getMesh (pure res) obj

--- a/Graphics/Implicit/Export/TriangleMeshFormats.hs
+++ b/Graphics/Implicit/Export/TriangleMeshFormats.hs
@@ -35,7 +35,7 @@ cleanupTris tris =
         floatPoint :: V3 ℝ -> (Float, Float, Float)
         floatPoint (V3 a b c) = (toFloat a, toFloat b, toFloat c)
 
-        -- | Does this triangle fail because it is constrained on two axises?
+        -- Does this triangle fail because it is constrained on two axises?
         isDegenerateTri2Axis :: Eq a => ((a, a, a),(a, a, a),(a, a, a)) -> Bool
         isDegenerateTri2Axis tri = (ysame tri && xsame tri) || (zsame tri && ysame tri) || (zsame tri && xsame tri)
           where

--- a/Graphics/Implicit/Export/Util.hs
+++ b/Graphics/Implicit/Export/Util.hs
@@ -15,7 +15,7 @@ import Graphics.Implicit.Definitions (ℝ, ℝ3, Obj3, Triangle(Triangle), Norme
 import Linear ((*^), (^/), normalize, V3(V3))
 import Data.List (foldl')
 
--- | Change the default for bare numbers in this file.
+-- Change the default for bare numbers in this file.
 default (ℝ)
 
 -- FIXME: magic numbers.

--- a/Graphics/Implicit/ExtOpenScad/Default.hs
+++ b/Graphics/Implicit/ExtOpenScad/Default.hs
@@ -135,7 +135,7 @@ varArgModules =
                 modifyVarLookup iter
                 runSuite suite
           where
-            -- | convert a list of arguments into a list of functions to transform the VarLookup with new bindings for each possible iteration.
+            -- convert a list of arguments into a list of functions to transform the VarLookup with new bindings for each possible iteration.
             iterator :: [(Maybe Symbol, OVal)] -> [VarLookup -> VarLookup]
             iterator [] = [id]
             iterator ((Nothing, _):iterators) = iterator iterators

--- a/Graphics/Implicit/ExtOpenScad/Definitions.hs
+++ b/Graphics/Implicit/ExtOpenScad/Definitions.hs
@@ -57,11 +57,11 @@ type StateC = StateT CompState IO
 -- | Handles parsing arguments to built-in modules
 data ArgParser a
                  = AP Symbol (Maybe OVal) Text (OVal -> ArgParser a)
-                 -- ^ For actual argument entries: @ArgParser (argument name) (default) (doc) (next Argparser...)@
+                 -- ^ For actual argument entries: @AP (argument name) (default) (doc) (next Argparser...)@
                  | APTerminator a
-                 -- ^ For returns: @ArgParserTerminator (return value)@
+                 -- ^ For returns: @APTerminator (return value)@
                  | APFail Text
-                 -- ^ For failure: @ArgParserFailIf (error message)@
+                 -- ^ For failure: @APFail (error message)@
                  | APExample Text (ArgParser a)
                  -- ^ An example, then next
                  | APTest Text [TestInvariant] (ArgParser a)

--- a/Graphics/Implicit/ExtOpenScad/Definitions.hs
+++ b/Graphics/Implicit/ExtOpenScad/Definitions.hs
@@ -56,21 +56,18 @@ type StateC = StateT CompState IO
 
 -- | Handles parsing arguments to built-in modules
 data ArgParser a
-                 -- | For actual argument entries:
-                 --   ArgParser (argument name) (default) (doc) (next Argparser...)
                  = AP Symbol (Maybe OVal) Text (OVal -> ArgParser a)
-                 -- | For returns:
-                 --   ArgParserTerminator (return value)
+                 -- ^ For actual argument entries: @ArgParser (argument name) (default) (doc) (next Argparser...)@
                  | APTerminator a
-                 -- | For failure:
-                 --   ArgParserFailIf (error message)
+                 -- ^ For returns: @ArgParserTerminator (return value)@
                  | APFail Text
-                 --  An example, then next
+                 -- ^ For failure: @ArgParserFailIf (error message)@
                  | APExample Text (ArgParser a)
-                 --  A string to run as a test, then invariants for the results, then next
+                 -- ^ An example, then next
                  | APTest Text [TestInvariant] (ArgParser a)
-                 -- A branch where there are a number of possibilities for the parser underneath
+                 -- ^ A string to run as a test, then invariants for the results, then next
                  | APBranch [ArgParser a]
+                 -- ^ A branch where there are a number of possibilities for the parser underneath
   deriving Functor
 
 instance Applicative ArgParser where

--- a/Graphics/Implicit/ExtOpenScad/Eval/Statement.hs
+++ b/Graphics/Implicit/ExtOpenScad/Eval/Statement.hs
@@ -50,11 +50,10 @@ import System.Directory (doesFileExist)
 
 import System.FilePath (takeDirectory)
 
--- Run statements out of the OpenScad file.
+-- | Run statements out of the OpenScad file.
 runStatementI :: StatementI -> StateC ()
-
--- | Interpret variable assignment
 runStatementI (StatementI sourcePos (pat := expr)) = do
+    -- Interpret variable assignment
     val <- evalExpr sourcePos expr
     let posMatch = matchPat pat val
     case (getErrors val, posMatch) of
@@ -67,8 +66,8 @@ runStatementI (StatementI sourcePos (pat := expr)) = do
             modifyVarLookup $ varUnion (VarLookup match)
         (_,   Nothing ) -> errorC sourcePos "pattern match failed in assignment"
 
--- | Interpret an if conditional statement.
 runStatementI (StatementI sourcePos (If expr a b)) = do
+    -- Interpret an if conditional statement.
     val <- evalExpr sourcePos expr
     case (getErrors val, val) of
         (Just err,  _  )  -> errorC sourcePos ("In conditional expression of if statement: " <> err)
@@ -76,8 +75,8 @@ runStatementI (StatementI sourcePos (If expr a b)) = do
         (_, OBool False)  -> runSuite b
         _                 -> pure ()
 
--- | Interpret a module declaration.
 runStatementI (StatementI sourcePos (NewModule name argTemplate suite)) = do
+    -- Interpret a module declaration.
     argTemplate' <- for argTemplate $ \(argName, defexpr) -> do
         defval <- traverse (evalExpr sourcePos) defexpr
         pure (argName, defval)
@@ -96,8 +95,8 @@ runStatementI (StatementI sourcePos (NewModule name argTemplate suite)) = do
             varlookup' = union (fromList newNameVals) varlookup
         pure $ runSuiteCapture (VarLookup varlookup') suite
 
--- | Interpret a call to a module.
 runStatementI (StatementI sourcePos (ModuleCall (Symbol name) argsExpr suite)) = do
+        -- Interpret a call to a module.
         maybeMod <- lookupVar (Symbol name)
         varlookup <- getVarLookup
         newVals  <- case maybeMod of
@@ -248,8 +247,8 @@ runStatementI (StatementI sourcePos (ModuleCall (Symbol name) argsExpr suite)) =
               val <- evalExpr sourcePos expr
               pure (posName, val)
 
--- | Interpret an include or use statement.
 runStatementI (StatementI sourcePos (Include name injectVals)) = do
+    -- Interpret an include or use statement.
     opts <- scadOptions
     if importsAllowed opts
       then do

--- a/Graphics/Implicit/ExtOpenScad/Parser/Util.hs
+++ b/Graphics/Implicit/ExtOpenScad/Parser/Util.hs
@@ -88,7 +88,7 @@ boolean = "boolean" ?:
   LitE . OBool <$> (matchTrue $> True <|> matchFalse $> False)
 
 -- | Parse a quoted string.
---   FIXME: no \u unicode support?
+--   FIXME: no @\u@ unicode support?
 scadString :: GenParser Char st Expr
 scadString = "string" ?: LitE . OString . pack <$>
     between

--- a/Graphics/Implicit/ExtOpenScad/Primitives.hs
+++ b/Graphics/Implicit/ExtOpenScad/Primitives.hs
@@ -110,7 +110,7 @@ sphere = moduleWithoutSuite "sphere" $ \_ _ -> do
     addObj3 $ Prim.sphere r
 
 -- | FIXME: square1, square2 like cylinder has?
--- | FIXME: translate for square2?
+--   FIXME: translate for square2?
 cube :: (Symbol, SourcePosition -> [OVal] -> ArgParser (StateC [OVal]))
 cube = moduleWithoutSuite "cube" $ \_ _ -> do
     -- examples
@@ -287,9 +287,9 @@ circle = moduleWithoutSuite "circle" $ \_ _ -> do
             [V2 (r*cos θ) (r*sin θ) | θ <- [2*pi*fromℕtoℝ n/fromℕtoℝ sides | n <- [0 .. sides - 1]]]
 
 -- | FIXME: 3D Polygons?
--- | FIXME: handle rectangles that are not grid alligned.
--- | FIXME: allow for rounding of polygon corners, specification of vertex ordering.
--- | FIXME: polygons have to have more than two points, or do not generate geometry, and generate an error.
+--   FIXME: handle rectangles that are not grid alligned.
+--   FIXME: allow for rounding of polygon corners, specification of vertex ordering.
+--   FIXME: polygons have to have more than two points, or do not generate geometry, and generate an error.
 polygon :: (Symbol, SourcePosition -> [OVal] -> ArgParser (StateC [OVal]))
 polygon = moduleWithoutSuite "polygon" $ \_ _ -> do
     example "polygon ([(0,0), (0,10), (10,0)]);"
@@ -389,8 +389,8 @@ translate = moduleWithSuite "translate" $ \_ children -> do
         objMap (Prim.translate (V2 x y)) (Prim.translate (V3 x y z)) children
 
 -- | FIXME: rotating a module that is not found pures no geometry, instead of an error.
--- | FIXME: error reporting on fallthrough.
--- + FIXME: rotate(y=90) would be nice.
+--   FIXME: error reporting on fallthrough.
+--   FIXME: rotate(y=90) would be nice.
 rotate :: (Symbol, SourcePosition -> [OVal] -> ArgParser (StateC [OVal]))
 rotate = moduleWithSuite "rotate" $ \_ children -> do
     a <- argument "a"

--- a/Graphics/Implicit/MathUtil.hs
+++ b/Graphics/Implicit/MathUtil.hs
@@ -150,7 +150,6 @@ pack (dx, dy) sep objs = packSome sortedObjs (dx, dy)
 -- | Reflect a vector across a hyperplane defined by its normal vector.
 --
 -- From https://en.wikipedia.org/wiki/Reflection_(mathematics)#Reflection_through_a_hyperplane_in_n_dimensions
---     -> ℝ2
 reflect
     :: (Num (f a), Fractional a, Metric f)
     => f a  -- ^ Mirror axis

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -415,10 +415,11 @@ rotate3V
     -> SymbolicObj3
 rotate3V w xyz = Rotate3 $ axisAngle xyz w
 
--- FIXME: shouldn't this pack into a 3d area, or have a 3d equivalent?
 -- | Attempt to pack multiple 3D objects into a fixed area. The @z@ coordinate
 -- of each object is dropped, and the resulting packed objects will all be on
 -- the same plane.
+--
+-- FIXME: shouldn't this pack into a 3d area, or have a 3d equivalent?
 pack3
     :: ℝ2                  -- ^ Area to pack
     -> ℝ                   -- ^ Separation between objects

--- a/programs/docgen.hs
+++ b/programs/docgen.hs
@@ -127,7 +127,6 @@ data DocPart = ExampleDoc String
 --   If so, we *back off*.
 
 -- | Extract Documentation from an ArgParser
-
 getArgParserDocs ::
     ArgParser a      -- ^ ArgParser(s)
     -> IO [DocPart]  -- ^ Docs (sadly IO wrapped)

--- a/programs/extopenscad.hs
+++ b/programs/extopenscad.hs
@@ -192,28 +192,30 @@ instance Read OutputFormat where
 
 -- | Find the resolution to raytrace at.
 getRes :: (VarLookup, [SymbolicObj2], [SymbolicObj3], [Message]) -> ℝ
--- | If specified, use a resolution specified by the "$res" a variable in the input file.
-getRes (lookupVarIn "$res" -> Just (ONum res), _, _, _) = res
--- | If there was no resolution specified, use a resolution chosen for 3D objects.
---   FIXME: magic numbers.
+getRes (lookupVarIn "$res" -> Just (ONum res), _, _, _) =
+    -- If specified, use a resolution specified by the "$res" a variable in the input file.
+    res
 getRes (vars, _, obj:objs, _) =
+    -- If there was no resolution specified, use a resolution chosen for 3D objects.
+    -- FIXME: magic numbers.
     let
         (V3 x1 y1 z1, V3 x2 y2 z2) = getBox (unionR 0 (obj:objs))
         (V3 x y z) = V3 (x2-x1) (y2-y1) (z2-z1)
     in case fromMaybe (ONum 1) $ lookupVarIn "$quality" vars of
         ONum qual | qual > 0  -> min (minimum [x,y,z]/2) ((x*y*z/qual)**(1/3) / 22)
         _                     -> min (minimum [x,y,z]/2) ((x*y*z)**(1/3) / 22)
--- | ... Or use a resolution chosen for 2D objects.
---   FIXME: magic numbers.
 getRes (vars, obj:objs, _, _) =
+    -- ... Or use a resolution chosen for 2D objects.
+    --   FIXME: magic numbers.
     let
         (p1,p2) = getBox (unionR 0 (obj:objs))
         (V2 x y) = p2 .-. p1
     in case fromMaybe (ONum 1) $ lookupVarIn "$quality" vars of
         ONum qual | qual > 0 -> min (min x y/2) (sqrt(x*y/qual) / 30)
         _                    -> min (min x y/2) (sqrt(x*y) / 30)
--- | fallthrough value.
-getRes _ = 1
+getRes _ =
+    -- fallthrough value.
+    1
 
 -- | Output a file containing a 3D object.
 export3 :: Maybe OutputFormat -> ℝ -> FilePath -> SymbolicObj3 -> IO ()

--- a/programs/implicitsnap.hs
+++ b/programs/implicitsnap.hs
@@ -94,9 +94,9 @@ renderHandler = method GET $ withCompression $ do
 
 -- | Find the resolution to raytrace at.
 getRes :: (VarLookup, [SymbolicObj2], [SymbolicObj3], [Message]) -> ℝ
--- | If specified, use a resolution specified by the "$res" a variable in the input file.
+-- If specified, use a resolution specified by the "$res" a variable in the input file.
 getRes (lookupVarIn "$res" -> Just (ONum res), _, _, _) = res
--- | If there was no resolution specified, use a resolution chosen for 3D objects.
+-- If there was no resolution specified, use a resolution chosen for 3D objects.
 --   FIXME: magic numbers.
 getRes (vars, _, obj:objs, _) =
     let
@@ -105,7 +105,7 @@ getRes (vars, _, obj:objs, _) =
     in case fromMaybe (ONum 1) $ lookupVarIn "$quality" vars of
         ONum qual | qual > 0  -> min (minimum [x,y,z]/2) ((x*y*z/qual)**(1/3) / 22)
         _                     -> min (minimum [x,y,z]/2) ((x*y*z)**(1/3) / 22)
--- | ... Or use a resolution chosen for 2D objects.
+-- ... Or use a resolution chosen for 2D objects.
 --   FIXME: magic numbers.
 getRes (vars, obj:objs, _, _) =
     let
@@ -114,7 +114,7 @@ getRes (vars, obj:objs, _, _) =
     in case fromMaybe (ONum 1) $ lookupVarIn "$quality" vars of
         ONum qual | qual > 0 -> min (min x y/2) (sqrt(x*y/qual) / 30)
         _                    -> min (min x y/2) (sqrt(x*y) / 30)
--- | fallthrough value.
+-- fallthrough value.
 getRes _ = 1
 
 -- | get the maximum dimension of the object being rendered.

--- a/tests/ExecSpec/Util.hs
+++ b/tests/ExecSpec/Util.hs
@@ -29,7 +29,7 @@ infixr 1 -->
 (-->) source value =
   runExpr source False `shouldBe` (value, [])
 
--- | Types
+-- Types
 
 num :: ℝ -> OVal
 num = ONum

--- a/tests/ImplicitSpec.hs
+++ b/tests/ImplicitSpec.hs
@@ -43,7 +43,7 @@ import Graphics.Implicit (mirror)
 
 
 ------------------------------------------------------------------------------
--- | Tests showing equivalencies between algebraic formulations of symbolic
+-- Tests showing equivalencies between algebraic formulations of symbolic
 -- objects, in both 2d and 3d. Equality is observational, based on random
 -- sampling of the underlying 'getImplicit' function.
 spec :: Spec
@@ -69,7 +69,7 @@ spec = do
 
 
 ------------------------------------------------------------------------------
--- | All the constraints we need in scope to parameterize tests by both 2d and
+-- All the constraints we need in scope to parameterize tests by both 2d and
 -- 3d symbolic objects.
 type TestInfrastructure obj vec test outcome =
   ( Object obj vec
@@ -85,7 +85,7 @@ type TestInfrastructure obj vec test outcome =
 
 
 ------------------------------------------------------------------------------
--- | Tests proving that symbolic objects form a monoid.
+-- Tests proving that symbolic objects form a monoid.
 monoidSpec
     :: forall obj vec test outcome
      . TestInfrastructure obj vec test outcome
@@ -102,7 +102,7 @@ monoidSpec = describe "monoid laws" $ do
 
 
 ------------------------------------------------------------------------------
--- | Tests showing that 'translate' is a no-op for both 'emptySpace' and
+-- Tests showing that 'translate' is a no-op for both 'emptySpace' and
 -- 'fullSpace'. Additionally, that 'scale' is a no-op on 'emptySpace' (but not
 -- for 'fullSpace', because scaling by 0 is instead 'emptySpace').
 idempotenceSpec
@@ -126,7 +126,7 @@ idempotenceSpec = describe "idempotence" $ do
 
 
 ------------------------------------------------------------------------------
--- | Proofs of the invertability of operations.
+-- Proofs of the invertability of operations.
 inverseSpec
     :: forall obj vec test outcome
      . TestInfrastructure obj vec test outcome
@@ -150,7 +150,7 @@ inverseSpec = describe "inverses" $ do
 
 
 ------------------------------------------------------------------------------
--- | Proofs that 'fullSpace' is an annhilative element with respect to union.
+-- Proofs that 'fullSpace' is an annhilative element with respect to union.
 annihilationSpec
     :: forall obj vec test outcome
      . TestInfrastructure obj vec test outcome
@@ -165,7 +165,7 @@ annihilationSpec = describe "annihilation" $ do
 
 
 ------------------------------------------------------------------------------
--- | Misc proofs regarding 2d rotation.
+-- Misc proofs regarding 2d rotation.
 rotation2dSpec :: Spec
 rotation2dSpec = describe "2d rotation" $ do
   prop "360 degrees is id" $
@@ -190,7 +190,7 @@ rotation2dSpec = describe "2d rotation" $ do
 
 
 ------------------------------------------------------------------------------
--- | Misc proofs regarding 3d rotation.
+-- Misc proofs regarding 3d rotation.
 rotation3dSpec :: Spec
 rotation3dSpec = describe "3d rotation" $ do
   for_ [ ("YZ", V3 1 0 0)
@@ -228,7 +228,7 @@ rotation3dSpec = describe "3d rotation" $ do
 
 
 ------------------------------------------------------------------------------
--- | Misc tests that make sense only in 3d
+-- Misc tests that make sense only in 3d
 misc3dSpec :: Spec
 misc3dSpec = describe "misc 3d tests" $ do
   prop "object-rounding value doesn't jump from 3d to 2d" $ \r obj ->
@@ -240,7 +240,7 @@ misc3dSpec = describe "misc 3d tests" $ do
 
 
 ------------------------------------------------------------------------------
--- | Misc identity proofs that should hold for all symbolic objects.
+-- Misc identity proofs that should hold for all symbolic objects.
 identitySpec
     :: forall obj vec test outcome
      . TestInfrastructure obj vec test outcome
@@ -271,7 +271,7 @@ identitySpec = describe "identity" $ do
 
 
 ------------------------------------------------------------------------------
--- | Functions proving symbolic objects form homomorphisms with respect to
+-- Functions proving symbolic objects form homomorphisms with respect to
 -- translate and scale.
 homomorphismSpec
     :: forall obj vec test outcome

--- a/tests/MessageSpec/Util.hs
+++ b/tests/MessageSpec/Util.hs
@@ -35,7 +35,6 @@ infixr 1 -->
   getOpenscadMessages scadOptions [] source `shouldReturn` value
   where
     scadOptions = generateScadOpts
--- | Types
 
 -- | An even smaller wrapper which runs a program, and only returns the generated messages. for the test suite.
 getOpenscadMessages ::  ScadOpts -> [String] -> String -> IO [Message]

--- a/tests/ParserSpec/Statement.hs
+++ b/tests/ParserSpec/Statement.hs
@@ -75,7 +75,7 @@ assignmentSpec = do
     fooFunction = Name "foo" := LamE [Name "x", Name "y"]
                                 (mult [Var "x", Var "y"])
 
--- | Test a simple if block.
+-- Test a simple if block.
 ifSpec :: Spec
 ifSpec = do
   it "parses" $
@@ -85,7 +85,7 @@ ifSpec = do
     "if ( true ) { a ( ) ; } else {b();}" -->
     single ( If (bool True) [call "a" 15 [] []] [call "b" 31 [] []])
 
--- | Our entry point. Test all of the statements.
+-- Our entry point. Test all of the statements.
 statementSpec :: Spec
 statementSpec = do
   describe "empty file" $

--- a/tests/ParserSpec/Statement.hs
+++ b/tests/ParserSpec/Statement.hs
@@ -37,10 +37,10 @@ pattern Name :: Text -> Pattern
 pattern Name n = GIED.Name (Symbol n)
 
 -- | an expectation that a string is equivalent to a statement.
-infixr 1 -->
 (-->) :: String -> [StatementI] -> Expectation
 (-->) source stmts =
     parseProgram "noname" source `shouldBe` Right stmts
+infixr 1 -->
 
 -- | A single statement.
 single :: Statement StatementI -> [StatementI]

--- a/tests/ParserSpec/Statement.hs
+++ b/tests/ParserSpec/Statement.hs
@@ -42,10 +42,6 @@ infixr 1 -->
 (-->) source stmts =
     parseProgram "noname" source `shouldBe` Right stmts
 
--- | an expectation that a string generates an error.
--- parsesAsError :: String -> Expectation
--- parsesAsError source = parseProgram "noname" source `shouldSatisfy` isLeft
-
 -- | A single statement.
 single :: Statement StatementI -> [StatementI]
 single st = [StatementI (SourcePosition 1 1 "noname") st]

--- a/tests/ParserSpec/Util.hs
+++ b/tests/ParserSpec/Util.hs
@@ -63,7 +63,7 @@ infixr 1 -->
 (-->) source expr =
   parse (expr0 <* eof) "<expr>" source `shouldBe` Right expr
 
--- | Types
+-- Types
 
 num :: ℝ -> Expr
 num x
@@ -81,7 +81,7 @@ stringLiteral = LitE . OString
 undefined :: Expr
 undefined = LitE OUndefined
 
--- | Operators
+-- Operators
 
 plus,minus,mult,modulo,power,divide,negate,and,or,not,gt,lt,ternary,append,index :: [Expr] -> Expr
 minus = oapp "-"

--- a/tests/ParserSpec/Util.hs
+++ b/tests/ParserSpec/Util.hs
@@ -100,9 +100,12 @@ index = oapp "index"
 append = oapp "++"
 plus = oapp "+"
 
--- | We need two different kinds of application functions, one for operators, and one for functions.
-oapp,fapp :: Text -> [Expr] -> Expr
+-- | We need two different kinds of application functions, one for operators, and one for functions.  See also: 'fapp'.
+oapp :: Text -> [Expr] -> Expr
 oapp name args = Var (Symbol name) :$ args
+
+-- | See 'oapp'.
+fapp :: Text -> [Expr] -> Expr
 fapp name args = Var (Symbol name) :$ [ListE args]
 
 lambda :: [Pattern] -> Expr -> [Expr] -> Expr


### PR DESCRIPTION
Remove invalid `-- |` (haddock indexing) that confuse ormolu.

This is a small, hopefully uncontroversial step towards ormulizing ImplicitCad.  It may not be complete, ie. I may have missed some haddock syntax errors, but this PR should certainly improve things.

I removed indexing of identifiers like `spec` in the test suite because it didn't really make sense IMO.  It's not techincally invalid, and I'm happy to revert those changes if you disagree.  Same goes for some other changes, I've kept most of them in separate commits so we can easily drop them from the PR to make it even less controversial.

The upside of this is that haddocks will produce less warnings and more correct/complete documentation, and simplify applying ormolu at any point in the future.  The only downside I can think of is that it may cause some merge conflicts with existing branches.