### PR TITLE
play

### DIFF
--- a/Graphics/Implicit/MathUtil.hs
+++ b/Graphics/Implicit/MathUtil.hs
@@ -3,16 +3,17 @@
 -- Released under the GNU AGPLV3+, see LICENSE
 
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- A module of math utilities.
 module Graphics.Implicit.MathUtil (rmax, rmaximum, rminimum, distFromLineSeg, pack, box3sWithin, reflect, alaV3, packV3, unpackV3, quaternionToEuler, infty) where
 
 -- Explicitly include what we need from Prelude.
-import Prelude (Num, Fractional, Bool, RealFloat, Ordering, (.), (>), (<), (+), ($), (/), otherwise, not, (||), (&&), abs, (-), (*), sin, asin, pi, max, sqrt, min, compare, (<=), fst, snd, (<>), head, flip, maximum, minimum, (==), (>=), signum, atan2)
+import Prelude (Num, Fractional, Bool, RealFloat, Ordering, (.), (>), (<), (+), ($), (/), otherwise, not, (||), (&&), abs, (-), (*), sin, asin, pi, max, sqrt, min, compare, (<=), fst, snd, (<>), flip, (==), (>=), signum, atan2, error)
 
 import Graphics.Implicit.Definitions (ℝ, ℝ2, ℝ3, Box2)
 
-import Data.List (sort, sortBy, (!!))
+import Data.List (sort, sortBy)
 import Linear (Metric, (*^), norm, distance, normalize, dot, Quaternion(Quaternion), V2(V2), V3(V3))
 
 -- | The distance a point p is from a line segment (a,b)
@@ -78,16 +79,9 @@ rmaximum ::
     -> ℝ   -- ^ resulting number
 rmaximum _ [] = 0
 rmaximum _ [a] = a
-rmaximum r [a,b]
-  | r == 0    = max a b
-  | otherwise = rmax r a b
-rmaximum r l
-  | r == 0    = maximum l
-  | otherwise =
-    let
-        tops = sortBy (flip compare) l
-    in
-        rmax r (head tops) (tops !! 1)
+rmaximum r [a,b] = rmax r a b
+rmaximum r (sortBy (flip compare) -> (a:b:_:_)) = rmax r a b
+rmaximum _ _ = error "impossible."  -- (and with dependent types we could prove it!)
 
 -- | Like rmin but on a list.
 rminimum ::
@@ -96,16 +90,9 @@ rminimum ::
     -> ℝ   -- ^ resulting number
 rminimum _ [] = 0
 rminimum _ [a] = a
-rminimum r [a,b]
-  | r > 0     = rmin r a b
-  | otherwise = min a b
-rminimum r l
-  | r > 0 =
-    let
-        tops = sort l
-    in
-        rmin r (head tops) (tops !! 1)
-  | otherwise = minimum l
+rminimum r [a,b] = rmin r a b
+rminimum r (sort -> (a:b:_:_)) = rmin r a b
+rminimum _ _ = error "impossible."
 
 -- | Pack the given objects in a box the given size.
 pack ::


### PR DESCRIPTION
Small tweak.  Probably not very useful, but while I was trying (and failing) to understand the code, I did this, and I like it better than the original.  :)
I tested the new implementations against the old ones successfully:

```
main :: IO ()
main = do
  hspec $ do
   it "max" . property $ \(r, l) -> rmaximum r l `shouldBe` rmaximum' r l
   it "min" . property $ \(r, l) -> rminimum r l `shouldBe` rminimum' r l
```

I also played with criterion briefly.  For what it's worth (not all that much), run times *in ghci* got insignificantly better:

```
maincrit :: IO ()
maincrit = do
  -- samples :: [(ℝ, [ℝ])] <- drop 10097 . read <$> readFile "/tmp/x"
  let samples = [(25.926064953677233,[-37.55079159856834,23.567519249918973,-25.980876710568026,16.867628533671432,46.58714263295459,-39.97978063375988,0.8004218912605194,-45.74401236643563,-42.84418123181723,-19.143006210152016,52.74574823650256,-66.40739774873268,41.111942952077165,-43.517157735564496,65.53443855286386,15.536710444268946,10.461306940703054,-66.79203888503767,-56.2658307416179,-50.269796895905394,3.6180058736496723,-52.56536905818381,88.22575821907058,-95.5621499679936,9.669383584834291,-53.03890894053863,91.52917528857618,-25.475657113569785,6.524417427183642,-96.55618841464111,54.54494155076025,-19.83864274794743,-18.763381447039787,-3.3412084101708217,-89.06627093022345,-92.66338441942746,-82.56399135670962,66.65425411080247,-61.522752153491496,58.77195896293415,52.42138122819853,-42.46186535001783,0.15271270533555983,-88.99400293490532,-26.69225773306577,41.36003054602528,45.45170925682786,67.89821849111812,-29.60326988782077,-30.670899568270848,31.927309024709125,10.52292869309314,23.20128002460128,-51.479004075175865,47.38160943317773,69.58887668772468,-21.19348681345879,-89.4782033702257,-43.820802023673224,-89.45143706292467,90.89651993542324,68.56775866975077,7.593988258891761,94.38243744378902,-84.10217698403595,-30.259171973405017,-46.295592122554496,-55.59626719508014,-0.546206456984585,-81.53907769497927,26.63245271021882,26.58369433668718,-0.27758244077071637,33.69615172130296,-42.32693547808267,11.397180171225669,-62.698901439405525,56.927553247881335,-45.48715962032994,-92.35586354974062,17.885936050708462,-35.832220694145036,-36.0141956618472,31.600558410352228,62.39921966876017,7.822644919551999,-2.2954025421354407,-53.14794949354061,87.30718116775301,-82.96012796175748,-12.357693897743646,-59.60518397909797,-86.78806768790498,61.604815367022276,-37.55079159856834,23.567519249918973,-25.980876710568026,16.867628533671432,46.58714263295459,-39.97978063375988,0.8004218912605194,-45.74401236643563,-42.84418123181723,-19.143006210152016,52.74574823650256,-66.40739774873268,41.111942952077165,-43.517157735564496,65.53443855286386,15.536710444268946,10.461306940703054,-66.79203888503767,-56.2658307416179,-50.269796895905394,3.6180058736496723,-52.56536905818381,88.22575821907058,-95.5621499679936,9.669383584834291,-53.03890894053863,91.52917528857618,-25.475657113569785,6.524417427183642,-96.55618841464111,54.54494155076025,-19.83864274794743,-18.763381447039787,-3.3412084101708217,-89.06627093022345,-92.66338441942746,-82.56399135670962,66.65425411080247,-61.522752153491496,58.77195896293415,52.42138122819853,-42.46186535001783,0.15271270533555983,-88.99400293490532,-26.69225773306577,41.36003054602528,45.45170925682786,67.89821849111812,-29.60326988782077,-30.670899568270848,31.927309024709125,10.52292869309314,23.20128002460128,-51.479004075175865,47.38160943317773,69.58887668772468,-21.19348681345879,-89.4782033702257,-43.820802023673224,-89.45143706292467,90.89651993542324,68.56775866975077])]
  print $ length samples
  Cr.defaultMain [
    Cr.bgroup "rmaximum" ((\(r, l) -> Cr.bench (show (r, l)) $ Cr.whnf (uncurry rmaximum) (r, l)) <$> samples),
    Cr.bgroup "rmaximum'" ((\(r, l) -> Cr.bench (show (r, l)) $ Cr.whnf (uncurry rmaximum') (r, l)) <$> samples)
   ]
```

Feel free to reject for whatever reason, just felt like sharing this.  Thanks!
