### PR TITLE
cabal: remove quickspec from libstuff dependencies

### DIFF
--- a/implicit.cabal
+++ b/implicit.cabal
@@ -94,7 +94,6 @@ Library
                   mtl,
                   linear,
                   QuickCheck,
-                  quickspec,
                   show-combinators,
                   lens
 


### PR DESCRIPTION
Only part of test-suite deps since it's only needed by tests.